### PR TITLE
Force serial sphinx build on RTD (-j 1 + explicit source dir)

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -4,18 +4,13 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.12"
-
-python:
-  install:
-    - method: pip
-      path: .
-      extra_requirements:
-        - docs
-
-sphinx:
-  configuration: docs/conf.py
-  fail_on_warning: false
-
-formats:
-  - pdf
-  - htmlzip
+  # RTD's default sphinx invocation uses `-j auto` and passes the repo
+  # root as the source directory. The parallel autodoc workers deadlock
+  # while introspecting udaan's module tree on the headless builder, and
+  # the implicit source dir makes debugging harder. Override with an
+  # explicit serial invocation, a hard timeout, and docs/ as source.
+  commands:
+    - python -m pip install --upgrade pip
+    - python -m pip install .[docs]
+    - mkdir -p $READTHEDOCS_OUTPUT/html
+    - timeout 600 python -m sphinx -T -j 1 -b html docs $READTHEDOCS_OUTPUT/html


### PR DESCRIPTION
## Summary
RTD builds hang at ~67% during autodoc even after the \`autodoc_mock_imports\` expansion in #4. Root cause: RTD's default sphinx invocation uses \`-j auto\`, and the parallel autodoc workers deadlock when introspecting udaan's module tree (autodoc + mock + importlib concurrent workers interact badly on headless containers).

Replace the declarative \`sphinx:\` block in \`.readthedocs.yaml\` with an explicit \`build.commands\` override:

\`\`\`yaml
build.commands:
  - python -m pip install --upgrade pip
  - python -m pip install .[docs]
  - mkdir -p \$READTHEDOCS_OUTPUT/html
  - timeout 600 python -m sphinx -T -j 1 -b html docs \$READTHEDOCS_OUTPUT/html
\`\`\`

- **\`-j 1\`** — serial autodoc, no worker deadlocks.
- **\`docs\`** — explicit source directory.
- **\`timeout 600\`** — hard 10-minute ceiling so regressions fail fast.
- Drops \`formats: [pdf, htmlzip]\` — not needed, just extra build time.

## Test plan
- [ ] After merge, the next RTD build on \`latest\` reaches the end of sphinx instead of timing out.
- [ ] /en/latest/ renders the full site (README, Guides, Preliminaries, API).

🤖 Generated with [Claude Code](https://claude.com/claude-code)