### PR TITLE
Flatness: Quadrotor flat-to-state map

### DIFF
--- a/tests/flatness/test_quadrotor.py
+++ b/tests/flatness/test_quadrotor.py
@@ -1,0 +1,319 @@
+"""Unit tests for :class:`udaan.flatness.Quadrotor` — the rigid-body
+quadrotor differential-flatness map."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from udaan.core.defaults import DEFAULT_QUAD_INERTIA, DEFAULT_QUAD_MASS, GRAVITY
+from udaan.flatness import Jet, Quadrotor, QuadrotorFlats
+from udaan.models.quadrotor.base import QuadrotorBase
+
+# ─── Helpers ──────────────────────────────────────────────────────────
+
+
+def _zero_flats() -> QuadrotorFlats:
+    """Hover flats: position and yaw jets all zero."""
+    return QuadrotorFlats(x=Jet.zeros(order=4, dim=3), psi=Jet.zeros(order=2, dim=1))
+
+
+def _circle_flats(
+    t: float, omega: float = 0.5, radius: float = 1.0, height: float = 1.0
+) -> QuadrotorFlats:
+    """Analytic flats for a horizontal circle at constant altitude with the
+    quadrotor yaw tracking the heading angle.
+
+    x(t) = [r cos(ωt), r sin(ωt), h],   ψ(t) = ω t
+
+    The non-zero ψ̇ and ψ̈ exercise the yaw-derivative paths in
+    ``Quadrotor.recover``. (For a circle ψ̇ = ω is constant, so ψ̈ = 0; an
+    additional yaw-acceleration check lives in ``TestYawWithAcceleration``.)
+    """
+    ct, st = np.cos(omega * t), np.sin(omega * t)
+    pos = np.array([radius * ct, radius * st, height])
+    vel = np.array([-radius * omega * st, radius * omega * ct, 0.0])
+    acc = np.array([-radius * omega**2 * ct, -radius * omega**2 * st, 0.0])
+    jerk = np.array([radius * omega**3 * st, -radius * omega**3 * ct, 0.0])
+    snap = np.array([radius * omega**4 * ct, radius * omega**4 * st, 0.0])
+    x_jet = Jet.from_list([pos, vel, acc, jerk, snap])
+    psi_jet = Jet(np.array([omega * t, omega, 0.0]))
+    return QuadrotorFlats(x=x_jet, psi=psi_jet)
+
+
+# ─── Construction ─────────────────────────────────────────────────────
+
+
+class TestConstruction:
+    def test_build_from_physical_params(self):
+        q = Quadrotor(mass=DEFAULT_QUAD_MASS, inertia=DEFAULT_QUAD_INERTIA)
+        assert q.mass == pytest.approx(DEFAULT_QUAD_MASS)
+        np.testing.assert_allclose(q.inertia, DEFAULT_QUAD_INERTIA)
+
+    def test_from_model_reads_model_params(self):
+        model = QuadrotorBase()
+        q = Quadrotor.from_model(model)
+        assert q.mass == pytest.approx(model.mass)
+        np.testing.assert_allclose(q.inertia, model.inertia)
+
+    def test_inertia_shape_validated(self):
+        with pytest.raises(ValueError, match="inertia must be 3×3"):
+            Quadrotor(mass=1.0, inertia=np.zeros((2, 2)))
+
+    def test_class_attribute_triple_declared(self):
+        # Flat2State contract — all three attributes present.
+        assert Quadrotor.Flats is QuadrotorFlats
+        assert Quadrotor.RefState.__name__ == "QuadrotorRefState"
+        assert Quadrotor.Inputs.__name__ == "QuadrotorInputs"
+
+
+# ─── QuadrotorFlats validation ────────────────────────────────────────
+
+
+class TestFlatsValidation:
+    def test_valid_order_flats_construct(self):
+        x = Jet.zeros(order=4, dim=3)
+        psi = Jet.zeros(order=2, dim=1)
+        # Should not raise.
+        QuadrotorFlats(x=x, psi=psi)
+
+    def test_higher_order_flats_also_accepted(self):
+        x = Jet.zeros(order=6, dim=3)
+        psi = Jet.zeros(order=3, dim=1)
+        QuadrotorFlats(x=x, psi=psi)
+
+    def test_x_wrong_dim_rejected(self):
+        with pytest.raises(ValueError, match="x must be a 3-D jet"):
+            QuadrotorFlats(x=Jet.zeros(order=4, dim=2), psi=Jet.zeros(order=2, dim=1))
+
+    def test_x_insufficient_order_rejected(self):
+        with pytest.raises(ValueError, match=r"x.order must be >= 4"):
+            QuadrotorFlats(x=Jet.zeros(order=3, dim=3), psi=Jet.zeros(order=2, dim=1))
+
+    def test_psi_not_scalar_rejected(self):
+        with pytest.raises(ValueError, match="psi must be a scalar jet"):
+            QuadrotorFlats(x=Jet.zeros(order=4, dim=3), psi=Jet.zeros(order=2, dim=3))
+
+    def test_psi_insufficient_order_rejected(self):
+        with pytest.raises(ValueError, match=r"psi.order must be >= 2"):
+            QuadrotorFlats(x=Jet.zeros(order=4, dim=3), psi=Jet.zeros(order=1, dim=1))
+
+
+# ─── Hover recovery ───────────────────────────────────────────────────
+
+
+class TestHover:
+    @pytest.fixture
+    def quad(self):
+        return Quadrotor(mass=DEFAULT_QUAD_MASS, inertia=DEFAULT_QUAD_INERTIA)
+
+    @pytest.fixture
+    def ref_inputs(self, quad):
+        return quad.recover(_zero_flats())
+
+    def test_hover_thrust_equals_weight(self, ref_inputs):
+        _, inputs = ref_inputs
+        assert inputs.thrust == pytest.approx(DEFAULT_QUAD_MASS * GRAVITY, abs=1e-10)
+
+    def test_hover_moment_is_zero(self, ref_inputs):
+        _, inputs = ref_inputs
+        np.testing.assert_allclose(inputs.moment, np.zeros(3), atol=1e-10)
+
+    def test_hover_orientation_is_identity(self, ref_inputs):
+        ref, _ = ref_inputs
+        R = np.asarray(ref.orientation)
+        err = np.linalg.norm(R - np.eye(3), ord="fro")
+        assert err == pytest.approx(0.0, abs=1e-10)
+
+    def test_hover_angular_velocity_and_accel_zero(self, ref_inputs):
+        ref, _ = ref_inputs
+        np.testing.assert_allclose(np.asarray(ref.angular_velocity), np.zeros(3), atol=1e-10)
+        np.testing.assert_allclose(ref.angular_acceleration, np.zeros(3), atol=1e-10)
+
+
+# ─── Constant-acceleration recovery ───────────────────────────────────
+
+
+class TestConstantAccel:
+    @pytest.fixture
+    def quad(self):
+        return Quadrotor(mass=DEFAULT_QUAD_MASS, inertia=DEFAULT_QUAD_INERTIA)
+
+    @pytest.fixture
+    def ref_inputs(self, quad):
+        x_jet = Jet.from_list(
+            [np.zeros(3), np.zeros(3), np.array([1.0, 0.0, 0.0]), np.zeros(3), np.zeros(3)]
+        )
+        psi_jet = Jet.zeros(order=2, dim=1)
+        return quad.recover(QuadrotorFlats(x=x_jet, psi=psi_jet))
+
+    def test_thrust_matches_m_sqrt_g2_plus_ax2(self, ref_inputs):
+        _, inputs = ref_inputs
+        expected = DEFAULT_QUAD_MASS * np.sqrt(GRAVITY**2 + 1.0**2)
+        assert inputs.thrust == pytest.approx(expected, abs=1e-10)
+        # And it should be strictly larger than hover thrust.
+        assert inputs.thrust > DEFAULT_QUAD_MASS * GRAVITY
+
+    def test_body_z_tilted_forward(self, ref_inputs):
+        ref, _ = ref_inputs
+        R = np.asarray(ref.orientation)
+        b3 = R[:, 2]
+        assert b3[0] > 0.0, "b3 should tilt in +x when accel is +x"
+        assert b3[2] > 0.0, "b3 should still point mostly +z"
+
+    def test_static_attitude_has_zero_angular_velocity(self, ref_inputs):
+        ref, _ = ref_inputs
+        np.testing.assert_allclose(np.asarray(ref.angular_velocity), np.zeros(3), atol=1e-10)
+
+
+# ─── Pure yaw-rate recovery ───────────────────────────────────────────
+
+
+class TestPureYawRate:
+    @pytest.fixture
+    def quad(self):
+        return Quadrotor(mass=DEFAULT_QUAD_MASS, inertia=DEFAULT_QUAD_INERTIA)
+
+    @pytest.fixture
+    def ref_inputs(self, quad):
+        x_jet = Jet.zeros(order=4, dim=3)
+        psi_jet = Jet(np.array([0.0, 0.5, 0.0]))
+        return quad.recover(QuadrotorFlats(x=x_jet, psi=psi_jet))
+
+    def test_angular_velocity_matches_yaw_rate(self, ref_inputs):
+        ref, _ = ref_inputs
+        Omega = np.asarray(ref.angular_velocity)
+        np.testing.assert_allclose(Omega[:2], np.zeros(2), atol=1e-10)
+        assert Omega[2] == pytest.approx(0.5, abs=1e-10)
+
+    def test_orientation_stays_identity_at_t0(self, ref_inputs):
+        # ψ = 0 at t=0 even though ψ̇ = 0.5 — instantaneous R should be I.
+        ref, _ = ref_inputs
+        R = np.asarray(ref.orientation)
+        np.testing.assert_allclose(R, np.eye(3), atol=1e-10)
+
+
+# ─── Yaw with non-zero second derivative ──────────────────────────────
+
+
+class TestYawWithAcceleration:
+    """Pure rotation about the world yaw axis with a non-zero ψ̈ — exercises
+    the dΩ recovery path that consumes the yaw acceleration."""
+
+    @pytest.fixture
+    def quad(self):
+        return Quadrotor(mass=DEFAULT_QUAD_MASS, inertia=DEFAULT_QUAD_INERTIA)
+
+    @pytest.fixture
+    def ref_inputs(self, quad):
+        x_jet = Jet.zeros(order=4, dim=3)
+        # ψ = 0, ψ̇ = 0.5, ψ̈ = 0.3 — all three derivatives non-trivial.
+        psi_jet = Jet(np.array([0.0, 0.5, 0.3]))
+        return quad.recover(QuadrotorFlats(x=x_jet, psi=psi_jet))
+
+    def test_angular_velocity_yaw_axis(self, ref_inputs):
+        ref, _ = ref_inputs
+        Omega = np.asarray(ref.angular_velocity)
+        np.testing.assert_allclose(Omega[:2], np.zeros(2), atol=1e-10)
+        assert Omega[2] == pytest.approx(0.5, abs=1e-10)
+
+    def test_angular_acceleration_yaw_axis(self, ref_inputs):
+        ref, _ = ref_inputs
+        dOmega = np.asarray(ref.angular_acceleration)
+        # With zero translational accel and pure-yaw rotation, dΩ should be
+        # entirely along world e3 and equal to ψ̈ at t = 0 (R = I).
+        np.testing.assert_allclose(dOmega[:2], np.zeros(2), atol=1e-10)
+        assert dOmega[2] == pytest.approx(0.3, abs=1e-10)
+
+    def test_moment_yaw_axis(self, ref_inputs):
+        _, inputs = ref_inputs
+        # M = J dΩ + Ω × J Ω. At hover with pure yaw motion both terms lie
+        # along e3 (Ω × J Ω is zero when Ω is along a principal axis and the
+        # inertia is diagonal). Off-axis components must vanish.
+        np.testing.assert_allclose(inputs.moment[:2], np.zeros(2), atol=1e-10)
+        # The e3 component is J_zz · ψ̈ (no Coriolis contribution here).
+        Jzz = DEFAULT_QUAD_INERTIA[2, 2]
+        assert inputs.moment[2] == pytest.approx(Jzz * 0.3, abs=1e-10)
+
+
+# ─── Integrator round-trip ────────────────────────────────────────────
+
+
+class TestRoundTrip:
+    """Recover (ref, inputs) from an analytic circular flat output, step a
+    ``QuadrotorBase`` with the feedforward wrench, and confirm the integrated
+    state tracks the analytic reference at the next sample."""
+
+    @pytest.fixture
+    def quad(self):
+        return Quadrotor(mass=DEFAULT_QUAD_MASS, inertia=DEFAULT_QUAD_INERTIA)
+
+    @pytest.fixture
+    def model(self):
+        return QuadrotorBase(input="wrench")
+
+    def test_one_step_tracks_analytic_reference(self, quad, model):
+        omega = 0.5
+        radius = 1.0
+        height = 1.0
+
+        # Recover at t=0.
+        flats0 = _circle_flats(0.0, omega=omega, radius=radius, height=height)
+        ref0, u0 = quad.recover(flats0)
+
+        # Seed the model with the reference state at t=0.
+        state0 = ref0.as_state()
+        model.reset(
+            position=state0.position,
+            velocity=state0.velocity,
+            orientation=state0.orientation,
+            angular_velocity=state0.angular_velocity,
+        )
+
+        # Feedforward wrench input.
+        u = np.array([u0.thrust, *u0.moment])
+
+        # One outer step (dt = 5 ms, 4 inner substeps at h = 1.25 ms).
+        model.step(u)
+        t_next = model.t
+
+        # Analytic flats at the next sample, and the reference state there.
+        flats1 = _circle_flats(t_next, omega=omega, radius=radius, height=height)
+        ref1, _ = quad.recover(flats1)
+
+        # Position and velocity should track the analytic reference tightly
+        # — ZOH over 5 ms, smooth trajectory.
+        np.testing.assert_allclose(model.state.position, ref1.position, atol=1e-3)
+        np.testing.assert_allclose(model.state.velocity, ref1.velocity, atol=1e-3)
+
+        # Attitude error (Frobenius) — smooth reference, short horizon.
+        R_sim = np.asarray(model.state.orientation)
+        R_ref = np.asarray(ref1.orientation)
+        att_err = np.linalg.norm(R_sim - R_ref, ord="fro")
+        assert att_err < 1e-2
+
+    def test_two_steps_tracks_analytic_reference(self, quad, model):
+        omega = 0.5
+        radius = 1.0
+        height = 1.0
+
+        flats0 = _circle_flats(0.0, omega=omega, radius=radius, height=height)
+        ref0, _ = quad.recover(flats0)
+        model.reset(
+            position=ref0.position,
+            velocity=ref0.velocity,
+            orientation=ref0.orientation,
+            angular_velocity=ref0.angular_velocity,
+        )
+
+        # Two outer steps, re-recovering the feedforward input each outer tick.
+        for _ in range(2):
+            flats_t = _circle_flats(model.t, omega=omega, radius=radius, height=height)
+            _, u_t = quad.recover(flats_t)
+            model.step(np.array([u_t.thrust, *u_t.moment]))
+
+        flats_end = _circle_flats(model.t, omega=omega, radius=radius, height=height)
+        ref_end, _ = quad.recover(flats_end)
+
+        np.testing.assert_allclose(model.state.position, ref_end.position, atol=1e-2)
+        np.testing.assert_allclose(model.state.velocity, ref_end.velocity, atol=1e-2)

--- a/tests/flatness/test_quadrotor_feedforward.py
+++ b/tests/flatness/test_quadrotor_feedforward.py
@@ -1,0 +1,271 @@
+"""Open-loop feedforward tracking tests for the quadrotor flat-to-state map.
+
+The flat-output-derived (f, M) is fed straight into the wrench-input dynamics
+without any closed-loop controller. Tracking error after 10 s should be
+bounded by the integrator's residual — purely numerical, not controller-
+driven.
+
+Two integrators are exercised:
+  - The shipped ZOH-Euler in QuadrotorBase (h = 1.25 ms inner step,
+    feed-forward held constant across the 5 ms outer step).
+  - A high-order adaptive RK (DOP853 via scipy.integrate.solve_ivp)
+    re-evaluating (f, M) continuously and using a quaternion attitude
+    parameterisation. Drives integrator error effectively to round-off,
+    so any non-zero residue is direct evidence of a flat-to-state
+    formula bug.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from scipy.integrate import solve_ivp
+from scipy.spatial.transform import Rotation as _ScipyRot
+
+from udaan.core.defaults import DEFAULT_QUAD_INERTIA, DEFAULT_QUAD_MASS, GRAVITY
+from udaan.flatness import Jet, Quadrotor, QuadrotorFlats
+from udaan.manif import SO3
+from udaan.models.quadrotor import QuadrotorBase
+
+TF = 10.0
+
+
+# ─── Trajectory builders ──────────────────────────────────────────────
+
+
+def hover_flats(t: float) -> QuadrotorFlats:
+    """Stationary hover at [0, 0, 1] with yaw = 0."""
+    x_data = np.zeros((5, 3))
+    x_data[0] = np.array([0.0, 0.0, 1.0])
+    psi_data = np.zeros(3)
+    return QuadrotorFlats(x=Jet(x_data), psi=Jet(psi_data))
+
+
+def circle_flats(t: float, r: float = 1.0, omega: float = 1.0, z0: float = 1.0) -> QuadrotorFlats:
+    """Circle in the XY plane at height z0; yaw tracks heading angle ωt."""
+    c, s = np.cos(omega * t), np.sin(omega * t)
+    x_data = np.array(
+        [
+            [r * c, r * s, z0],
+            [-r * omega * s, r * omega * c, 0.0],
+            [-r * omega**2 * c, -r * omega**2 * s, 0.0],
+            [r * omega**3 * s, -r * omega**3 * c, 0.0],
+            [r * omega**4 * c, r * omega**4 * s, 0.0],
+        ]
+    )
+    psi_data = np.array([omega * t, omega, 0.0])
+    return QuadrotorFlats(x=Jet(x_data), psi=Jet(psi_data))
+
+
+# ─── Harness ──────────────────────────────────────────────────────────
+
+
+def _f2s_default() -> Quadrotor:
+    return Quadrotor(mass=DEFAULT_QUAD_MASS, inertia=DEFAULT_QUAD_INERTIA)
+
+
+def _seed_model(model: QuadrotorBase, ref) -> None:
+    model.reset(
+        position=np.asarray(ref.position).copy(),
+        velocity=np.asarray(ref.velocity).copy(),
+        orientation=ref.orientation,
+        angular_velocity=ref.angular_velocity,
+    )
+
+
+def _run_open_loop(flats_of_t, tf: float = TF) -> tuple:
+    """Seed the model from the t=0 reference, march with pure feedforward,
+    return final-state errors against the flat reference at tf."""
+    f2s = _f2s_default()
+    model = QuadrotorBase(input="wrench")
+
+    # Seed
+    ref0, _ = f2s.recover(flats_of_t(0.0))
+    _seed_model(model, ref0)
+
+    # March
+    while model.t < tf - 1e-9:
+        ref, inputs = f2s.recover(flats_of_t(model.t))
+        u = np.array([inputs.thrust, *inputs.moment])
+        model.step(u)
+
+    # Compare final state to reference at tf
+    ref_final, _ = f2s.recover(flats_of_t(tf))
+    pos_err = float(np.linalg.norm(model.state.position - ref_final.position))
+    vel_err = float(np.linalg.norm(model.state.velocity - ref_final.velocity))
+    att_err = float(SO3(np.asarray(ref_final.orientation)).config_error(model.state.orientation))
+    omega_err = float(
+        np.linalg.norm(
+            np.asarray(model.state.angular_velocity) - np.asarray(ref_final.angular_velocity)
+        )
+    )
+    return pos_err, vel_err, att_err, omega_err
+
+
+# ─── Tests ────────────────────────────────────────────────────────────
+
+
+class TestOpenLoopHover:
+    def test_tracking_error_is_purely_numerical(self):
+        pos, vel, att, om = _run_open_loop(hover_flats)
+
+        # Pure-feedforward hover with exact m·g thrust: the dynamics
+        # should stay perfectly stationary up to machine epsilon.
+        assert pos < 1e-10, f"position drift {pos:.2e} m"
+        assert vel < 1e-10, f"velocity drift {vel:.2e} m/s"
+        assert att < 1e-10, f"attitude drift {att:.2e}"
+        assert om < 1e-10, f"angular-velocity drift {om:.2e} rad/s"
+
+
+class TestOpenLoopCircle:
+    def test_tracking_error_is_purely_numerical(self):
+        pos, vel, att, om = _run_open_loop(circle_flats)
+
+        # ZOH-Euler at h = 1.25 ms over 10 s = 8000 substeps. Local
+        # truncation error O(h²) ≈ 1.5e-6, accumulated O(t·h) — sub-cm
+        # position drift, sub-degree attitude drift expected. Bounds set
+        # generously (~10× expected) to leave headroom for downstream
+        # changes that don't break the flatness math.
+        assert pos < 1e-2, f"position error {pos:.2e} m"
+        assert vel < 5e-2, f"velocity error {vel:.2e} m/s"
+        assert att < 1e-2, f"attitude error {att:.2e} (Morse-style)"
+        assert om < 5e-2, f"angular-velocity error {om:.2e} rad/s"
+
+
+# ─── High-order ODE integration (DOP853 + quaternion attitude) ────────
+
+
+def _rigid_body_rhs(t, y, m, J, J_inv, flats_of_t, f2s):
+    """Rigid-body ODE in state y = [x(3), v(3), q_wxyz(4), ω(3)] = 13D.
+
+    Uses the flat-to-state map at the *exact* current t for (f, M), not
+    a held value from the last outer-step grid point — so this is a
+    strictly tighter test of the flatness formula than the ZOH path.
+    """
+    pos, vel, q_wxyz, omega = y[0:3], y[3:6], y[6:10], y[10:13]
+    # Re-normalise quaternion against round-off (DOP853 tolerances handle
+    # this fine in practice, but cheap insurance).
+    q_wxyz = q_wxyz / np.linalg.norm(q_wxyz)
+    R = _ScipyRot.from_quat(
+        [q_wxyz[1], q_wxyz[2], q_wxyz[3], q_wxyz[0]]  # scipy uses xyzw
+    ).as_matrix()
+
+    _, inputs = f2s.recover(flats_of_t(t))
+    f, M = inputs.thrust, inputs.moment
+
+    # Translational
+    e3 = np.array([0.0, 0.0, 1.0])
+    accel = (f / m) * (R @ e3) - GRAVITY * e3
+
+    # Quaternion kinematics:  q̇ = ½ q ⊗ [0, ω]   (Hamilton, scalar-first)
+    w, x, y_, z = q_wxyz
+    p, q, r = omega
+    q_dot = 0.5 * np.array(
+        [
+            -x * p - y_ * q - z * r,
+            w * p - z * q + y_ * r,
+            z * p + w * q - x * r,
+            -y_ * p + x * q + w * r,
+        ]
+    )
+
+    # Rotational:  J ω̇ = M − ω × J ω
+    omega_dot = J_inv @ (M - np.cross(omega, J @ omega))
+
+    return np.concatenate([vel, accel, q_dot, omega_dot])
+
+
+def _run_high_order(flats_of_t, tf: float = TF) -> tuple:
+    """Same harness as `_run_open_loop`, but integrate with adaptive
+    DOP853 (8th-order RK with adaptive step). Tight tolerances drive
+    integrator error to round-off, isolating any flat-to-state formula
+    error in the residual."""
+    f2s = _f2s_default()
+    m = DEFAULT_QUAD_MASS
+    J = np.asarray(DEFAULT_QUAD_INERTIA, dtype=float)
+    J_inv = np.linalg.inv(J)
+
+    # Seed from reference at t=0
+    ref0, _ = f2s.recover(flats_of_t(0.0))
+    R0 = np.asarray(ref0.orientation)
+    q0_xyzw = _ScipyRot.from_matrix(R0).as_quat()
+    q0_wxyz = np.array([q0_xyzw[3], q0_xyzw[0], q0_xyzw[1], q0_xyzw[2]])
+    y0 = np.concatenate(
+        [
+            np.asarray(ref0.position),
+            np.asarray(ref0.velocity),
+            q0_wxyz,
+            np.asarray(ref0.angular_velocity),
+        ]
+    )
+
+    sol = solve_ivp(
+        _rigid_body_rhs,
+        (0.0, tf),
+        y0,
+        method="DOP853",
+        rtol=1e-12,
+        atol=1e-12,
+        args=(m, J, J_inv, flats_of_t, f2s),
+        dense_output=False,
+    )
+    assert sol.success, f"DOP853 failed: {sol.message}"
+
+    yf = sol.y[:, -1]
+    pos_sim = yf[0:3]
+    vel_sim = yf[3:6]
+    q_wxyz = yf[6:10] / np.linalg.norm(yf[6:10])
+    R_sim = _ScipyRot.from_quat([q_wxyz[1], q_wxyz[2], q_wxyz[3], q_wxyz[0]]).as_matrix()
+    omega_sim = yf[10:13]
+
+    ref_final, _ = f2s.recover(flats_of_t(tf))
+    pos_err = float(np.linalg.norm(pos_sim - ref_final.position))
+    vel_err = float(np.linalg.norm(vel_sim - ref_final.velocity))
+    att_err = float(SO3(np.asarray(ref_final.orientation)).config_error(SO3(R_sim)))
+    omega_err = float(np.linalg.norm(omega_sim - np.asarray(ref_final.angular_velocity)))
+    return pos_err, vel_err, att_err, omega_err
+
+
+class TestOpenLoopCircleHighOrder:
+    """The circle test, re-run with DOP853 + quaternion attitude.
+
+    Errors should drop several orders of magnitude vs. the ZOH-Euler
+    version — confirming that the residual ZOH error is integrator
+    noise, not a flat-to-state formula bug.
+    """
+
+    def test_high_order_drives_error_to_roundoff(self):
+        pos, vel, att, om = _run_high_order(circle_flats)
+        # DOP853 at rtol=atol=1e-12 should drive position drift to
+        # picometer scale and attitude drift to round-off. Bounds are
+        # generous (~3 orders of magnitude above expected).
+        assert pos < 1e-7, f"position {pos:.2e} m"
+        assert vel < 1e-7, f"velocity {vel:.2e} m/s"
+        assert att < 1e-10, f"attitude {att:.2e}"
+        assert om < 1e-10, f"angular vel {om:.2e} rad/s"
+
+
+# ─── Diagnostic — run with `pytest -s` to print the actual numbers ────
+
+
+@pytest.mark.parametrize("name,builder", [("hover", hover_flats), ("circle", circle_flats)])
+def test_print_errors_zoh(name, builder):
+    pos, vel, att, om = _run_open_loop(builder)
+    print(
+        f"\n  [{name}] ZOH-Euler errors @ t={TF:.1f}s:"
+        f"\n    position    : {pos:.3e} m"
+        f"\n    velocity    : {vel:.3e} m/s"
+        f"\n    attitude Ψ  : {att:.3e}"
+        f"\n    angular vel : {om:.3e} rad/s"
+    )
+
+
+def test_print_errors_dop853_circle():
+    pos, vel, att, om = _run_high_order(circle_flats)
+    print(
+        f"\n  [circle, DOP853 rtol=atol=1e-12] errors @ t={TF:.1f}s:"
+        f"\n    position    : {pos:.3e} m"
+        f"\n    velocity    : {vel:.3e} m/s"
+        f"\n    attitude Ψ  : {att:.3e}"
+        f"\n    angular vel : {om:.3e} rad/s"
+    )

--- a/udaan/flatness/__init__.py
+++ b/udaan/flatness/__init__.py
@@ -5,13 +5,32 @@ Central type
 :class:`Jet` — a value and all its time derivatives up to some order,
 used as the input to every flat-to-state map in this package.
 
-Per-system flat-to-state maps are added as subclasses of :class:`Flat2State`.
+Per-system maps
+---------------
+:class:`Quadrotor` — flat-to-state recovery for a rigid-body quadrotor
+with flat output ``(x_Q, ψ)``.
 """
 
 from .base import Flat2State as Flat2State
 from .jet import Jet as Jet
+from .quadrotor import (
+    Quadrotor as Quadrotor,
+)
+from .quadrotor import (
+    QuadrotorFlats as QuadrotorFlats,
+)
+from .quadrotor import (
+    QuadrotorInputs as QuadrotorInputs,
+)
+from .quadrotor import (
+    QuadrotorRefState as QuadrotorRefState,
+)
 
 __all__ = [
     "Flat2State",
     "Jet",
+    "Quadrotor",
+    "QuadrotorFlats",
+    "QuadrotorInputs",
+    "QuadrotorRefState",
 ]

--- a/udaan/flatness/quadrotor.py
+++ b/udaan/flatness/quadrotor.py
@@ -1,0 +1,265 @@
+"""Differential flatness for the single rigid-body quadrotor.
+
+Flat output::
+
+    y = (x_Q, ψ)
+
+where x_Q ∈ R^3 is the centre-of-mass position and ψ ∈ R is the yaw angle.
+
+Derivative orders required::
+
+    x_Q through snap (x, ẋ, ẍ, x⃛, x⁽⁴⁾)
+    ψ   through ψ̈
+
+The map recovers the full state (x_Q, v_Q, R, Ω) plus the feedforward
+thrust and moment (f, M).
+
+Flat outputs are carried as :class:`Jet` bundles — ``x`` is a dim-3 jet
+of order ≥ 4 (through snap); ``psi`` is a scalar jet of order ≥ 2.
+
+Reference:
+    D. Mellinger and V. Kumar, "Minimum Snap Trajectory Generation and
+    Control for Quadrotors", ICRA 2011.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import numpy as np
+
+from ..core.defaults import GRAVITY
+from ..core.types import Mat3, Vec3
+from ..manif import SO3, TSO3, vee
+from .base import Flat2State
+from .jet import Jet
+
+_E3 = np.array([0.0, 0.0, 1.0])
+
+
+def _zeros3() -> Vec3:
+    return np.zeros(3)
+
+
+def _skew(m: np.ndarray) -> np.ndarray:
+    """Skew-symmetric part of a 3×3 matrix — ensures vee() is well-defined
+    even under floating-point noise."""
+    return 0.5 * (m - m.T)
+
+
+def _attitude_from_thrust_vector(
+    B: np.ndarray,
+    dB: np.ndarray,
+    d2B: np.ndarray,
+    psi: float,
+    dpsi: float,
+    d2psi: float,
+    J: np.ndarray,
+) -> tuple[float, np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    """Recover ``(f, R, Ω, dΩ, M)`` from the thrust-vector chain ``(B, dB, d2B)``
+    and yaw chain ``(ψ, ψ̇, ψ̈)``.
+
+    Used by every flat-to-state map whose thrust acts along the body z-axis:
+    once the caller has assembled ``B = f R e_3`` (in the form
+    ``m(ẍ + g e_3)`` for the standalone quadrotor, or
+    ``m_Q(ẍ_Q + g e_3) - 𝐓`` for the cspayload), the b_3-projector chain,
+    yaw-hint frame construction, skew-projector body rates, and Newton–Euler
+    moment are all the same.
+
+    Args:
+        B:     thrust vector ``f R e_3`` (R^3); must be non-vanishing.
+        dB:    first time derivative of B (R^3).
+        d2B:   second time derivative of B (R^3).
+        psi:   yaw angle.
+        dpsi:  yaw rate.
+        d2psi: yaw acceleration.
+        J:     quadrotor inertia matrix (3×3).
+
+    Returns:
+        ``(f, R, Ω, dΩ, M)`` where ``f = ‖B‖``, ``R ∈ SO(3)`` (3×3 ndarray),
+        ``Ω, dΩ ∈ R^3`` are body-frame rate / angular acceleration, and
+        ``M = J dΩ + Ω × J Ω`` is the body-frame moment.
+
+    Raises:
+        ValueError: if ``b_3 := B/‖B‖`` is parallel to the yaw-hint
+            ``[cos ψ, sin ψ, 0]ᵀ`` (yaw-aligned singularity). The caller
+            is responsible for the ``‖B‖ ≈ 0`` (free-fall) check.
+    """
+    norm_B = float(np.linalg.norm(B))
+    f = norm_B
+    b3 = B / norm_B
+
+    # Yaw-frame heading vector and its first two derivatives
+    cpsi, spsi = np.cos(psi), np.sin(psi)
+    b1d = np.array([cpsi, spsi, 0.0])
+    db1d = np.array([-spsi, cpsi, 0.0]) * dpsi
+    d2b1d = np.array([-cpsi, -spsi, 0.0]) * dpsi**2 + np.array([-spsi, cpsi, 0.0]) * d2psi
+
+    # Derivatives of ‖B‖ via d/dt(‖v‖) = v·v̇/‖v‖
+    dnorm_B = B.dot(dB) / norm_B
+    d2norm_B = (dB.dot(dB) + B.dot(d2B) - dnorm_B**2) / norm_B
+
+    # Derivatives of b_3 = B/‖B‖ (projector form, automatically perpendicular)
+    db3 = (dB - b3 * dnorm_B) / norm_B
+    d2b3 = (d2B - 2.0 * db3 * dnorm_B - b3 * d2norm_B) / norm_B
+
+    # Build R = [b1 b2 b3] with yaw-hint b1d
+    b3_x_b1d = np.cross(b3, b1d)
+    norm_b3_x_b1d = float(np.linalg.norm(b3_x_b1d))
+    if norm_b3_x_b1d < 1e-6:
+        raise ValueError(
+            "Thrust direction aligned with yaw hint — cannot construct a "
+            "unique desired attitude. Offset the yaw."
+        )
+    b2 = b3_x_b1d / norm_b3_x_b1d
+    b1 = np.cross(b2, b3)
+    R = np.column_stack([b1, b2, b3])
+
+    # First derivatives of {b1, b2} for Ω
+    db3_x_b1d = np.cross(db3, b1d) + np.cross(b3, db1d)
+    dnorm_b3_x_b1d = b3_x_b1d.dot(db3_x_b1d) / norm_b3_x_b1d
+    db2 = (db3_x_b1d - b2 * dnorm_b3_x_b1d) / norm_b3_x_b1d
+    db1 = np.cross(db2, b3) + np.cross(b2, db3)
+    dR = np.column_stack([db1, db2, db3])
+
+    # Body-frame angular velocity: Ω̂ = Rᵀ Ṙ
+    Omega = vee(_skew(R.T @ dR))
+
+    # Second derivatives of {b1, b2} for dΩ
+    d2b3_x_b1d = np.cross(d2b3, b1d) + 2.0 * np.cross(db3, db1d) + np.cross(b3, d2b1d)
+    d2norm_b3_x_b1d = (
+        db3_x_b1d.dot(db3_x_b1d) + b3_x_b1d.dot(d2b3_x_b1d) - dnorm_b3_x_b1d**2
+    ) / norm_b3_x_b1d
+    d2b2 = (d2b3_x_b1d - 2.0 * db2 * dnorm_b3_x_b1d - b2 * d2norm_b3_x_b1d) / norm_b3_x_b1d
+    d2b1 = np.cross(d2b2, b3) + 2.0 * np.cross(db2, db3) + np.cross(b2, d2b3)
+    d2R = np.column_stack([d2b1, d2b2, d2b3])
+
+    # dΩ̂ = skew(Rᵀ R̈) — symmetric Ω̂² piece cancels under the projector
+    dOmega = vee(_skew(R.T @ d2R))
+
+    # Feedforward moment: M = J dΩ + Ω × J Ω
+    M = J @ dOmega + np.cross(Omega, J @ Omega)
+
+    return f, R, Omega, dOmega, M
+
+
+@dataclass
+class QuadrotorFlats:
+    """Flat output of a rigid-body quadrotor: position jet (order ≥ 4)
+    and yaw-angle jet (order ≥ 2).
+
+    Attributes:
+        x:    dim-3 :class:`Jet` of the centre-of-mass position, with
+              derivatives through snap (order ≥ 4).
+        psi:  scalar :class:`Jet` of the yaw angle, with derivatives
+              through yaw acceleration (order ≥ 2).
+    """
+
+    x: Jet  # dim 3, order >= 4 (through snap)
+    psi: Jet  # dim 1 scalar, order >= 2 (through d2ψ̈)
+
+    def __post_init__(self):
+        if self.x.dim != 3:
+            raise ValueError(f"x must be a 3-D jet; got dim={self.x.dim}")
+        if self.x.order < 4:
+            raise ValueError(f"x.order must be >= 4 (snap); got {self.x.order}")
+        if not self.psi.is_scalar:
+            raise ValueError(f"psi must be a scalar jet; got dim={self.psi.dim}")
+        if self.psi.order < 2:
+            raise ValueError(f"psi.order must be >= 2; got {self.psi.order}")
+
+
+@dataclass
+class QuadrotorRefState:
+    """Recovered kinematic reference state for a quadrotor.
+
+    The first four fields mirror :class:`udaan.models.quadrotor.base.QuadrotorState`;
+    ``acceleration`` and ``angular_acceleration`` are extras that the
+    flatness map also makes available.
+    """
+
+    position: Vec3 = field(default_factory=_zeros3)
+    velocity: Vec3 = field(default_factory=_zeros3)
+    acceleration: Vec3 = field(default_factory=_zeros3)
+    orientation: SO3 = field(default_factory=SO3)
+    angular_velocity: TSO3 = field(default_factory=TSO3)
+    angular_acceleration: Vec3 = field(default_factory=_zeros3)
+
+    def as_state(self):
+        """Project onto the model's ``QuadrotorState`` shape (drops
+        acceleration + angular_acceleration)."""
+        from ..models.quadrotor.base import QuadrotorState
+
+        return QuadrotorState(
+            position=self.position,
+            velocity=self.velocity,
+            orientation=self.orientation,
+            angular_velocity=self.angular_velocity,
+        )
+
+
+@dataclass
+class QuadrotorInputs:
+    """Feedforward inputs recovered from the flat output."""
+
+    thrust: float = 0.0
+    moment: Vec3 = field(default_factory=_zeros3)
+
+
+class Quadrotor(Flat2State):
+    """Differential-flatness recovery for the single rigid-body quadrotor."""
+
+    Flats = QuadrotorFlats
+    RefState = QuadrotorRefState
+    Inputs = QuadrotorInputs
+
+    def __init__(self, mass: float, inertia: Mat3):
+        self.mass = float(mass)
+        self.inertia = np.asarray(inertia, dtype=float)
+        if self.inertia.shape != (3, 3):
+            raise ValueError(f"inertia must be 3×3, got {self.inertia.shape}")
+
+    @classmethod
+    def from_model(cls, model) -> Quadrotor:
+        """Build from a :class:`udaan.models.quadrotor.QuadrotorBase`-like model."""
+        return cls(mass=model.mass, inertia=model.inertia)
+
+    def recover(self, flats: QuadrotorFlats) -> tuple[QuadrotorRefState, QuadrotorInputs]:
+        g = GRAVITY
+        m = self.mass
+        J = self.inertia
+
+        # Pull named derivatives off the jets — position through snap,
+        # yaw through yaw-acceleration.
+        pos = flats.x.value
+        vel = flats.x.velocity
+        acc = flats.x.acceleration
+        jerk = flats.x.jerk
+        snap = flats.x.snap
+        psi = flats.psi.value
+        dpsi = flats.psi.velocity
+        d2psi = flats.psi.acceleration
+
+        # Thrust vector  B = f R e_3 = m (ẍ + g e_3)  and its time derivatives.
+        B = m * (acc + g * _E3)
+        dB = m * jerk
+        d2B = m * snap
+
+        if float(np.linalg.norm(B)) < 1e-6:
+            # Free-fall singularity — no unique thrust direction. Return a
+            # degraded reference (kinematics only, zero feedforward).
+            ref = QuadrotorRefState(position=pos, velocity=vel, acceleration=acc)
+            return ref, QuadrotorInputs()
+
+        f, R, Omega, dOmega, moment = _attitude_from_thrust_vector(B, dB, d2B, psi, dpsi, d2psi, J)
+
+        ref = QuadrotorRefState(
+            position=pos,
+            velocity=vel,
+            acceleration=acc,
+            orientation=SO3(R),
+            angular_velocity=TSO3(Omega),
+            angular_acceleration=dOmega,
+        )
+        inputs = QuadrotorInputs(thrust=f, moment=moment)
+        return ref, inputs

--- a/udaan/flatness/quadrotor.py
+++ b/udaan/flatness/quadrotor.py
@@ -8,7 +8,7 @@ where x_Q ∈ R^3 is the centre-of-mass position and ψ ∈ R is the yaw angle.
 
 Derivative orders required::
 
-    x_Q through snap (x, ẋ, ẍ, x⃛, x⁽⁴⁾)
+    x_Q through snap (x, ẋ, ẍ, x⁽³⁾, x⁽⁴⁾)
     ψ   through ψ̈
 
 The map recovers the full state (x_Q, v_Q, R, Ω) plus the feedforward


### PR DESCRIPTION
**Breakup of #8 — part 2.** Stacked on `feature/flatness-jet`. Adds the `Quadrotor` map + shared `_attitude_from_thrust_vector` helper + tests + ODE round-trip harness. Merge after the Jet PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)