### PR TITLE
Flatness: QuadrotorCsPayload flat-to-state map

### DIFF
--- a/tests/flatness/test_quadrotor_cspayload.py
+++ b/tests/flatness/test_quadrotor_cspayload.py
@@ -1,0 +1,384 @@
+"""Unit tests for :class:`udaan.flatness.QuadrotorCsPayload` — the
+quadrotor + cable-suspended-point-mass-payload differential-flatness map."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from udaan.core.defaults import (
+    DEFAULT_CABLE_LENGTH,
+    DEFAULT_PAYLOAD_MASS,
+    DEFAULT_QUAD_INERTIA,
+    DEFAULT_QUAD_MASS,
+    GRAVITY,
+)
+from udaan.flatness import (
+    Jet,
+    QuadrotorCsPayload,
+    QuadrotorCsPayloadFlats,
+)
+from udaan.models.quadrotor_cspayload.base import QuadrotorCsPayloadBase
+
+# ─── Helpers ──────────────────────────────────────────────────────────
+
+
+def _zero_flats() -> QuadrotorCsPayloadFlats:
+    """Hover flats: payload position and yaw jets all zero."""
+    return QuadrotorCsPayloadFlats(
+        x_L=Jet.zeros(order=6, dim=3),
+        psi=Jet.zeros(order=2, dim=1),
+    )
+
+
+def _circle_flats(
+    t: float, omega: float = 0.5, radius: float = 0.4, height: float = 1.0
+) -> QuadrotorCsPayloadFlats:
+    """Analytic flats for a horizontal payload circle at constant altitude
+    with the quadrotor yaw tracking the heading angle.
+
+    x_L(t) = [r cos(ωt), r sin(ωt), h],   ψ(t) = ω t
+
+    The radius is kept small so the swing angle stays well within the
+    taut-cable / non-singular regime (T > 0 throughout).
+    """
+    ct, st = np.cos(omega * t), np.sin(omega * t)
+    rows = []
+    rows.append(np.array([radius * ct, radius * st, height]))
+    rows.append(np.array([-radius * omega * st, radius * omega * ct, 0.0]))
+    rows.append(np.array([-radius * omega**2 * ct, -radius * omega**2 * st, 0.0]))
+    rows.append(np.array([radius * omega**3 * st, -radius * omega**3 * ct, 0.0]))
+    rows.append(np.array([radius * omega**4 * ct, radius * omega**4 * st, 0.0]))
+    rows.append(np.array([-radius * omega**5 * st, radius * omega**5 * ct, 0.0]))
+    rows.append(np.array([-radius * omega**6 * ct, -radius * omega**6 * st, 0.0]))
+    x_jet = Jet.from_list(rows)
+    psi_jet = Jet(np.array([omega * t, omega, 0.0]))
+    return QuadrotorCsPayloadFlats(x_L=x_jet, psi=psi_jet)
+
+
+# ─── Construction ─────────────────────────────────────────────────────
+
+
+class TestConstruction:
+    def test_build_from_physical_params(self):
+        f2s = QuadrotorCsPayload(
+            mass_q=DEFAULT_QUAD_MASS,
+            mass_l=DEFAULT_PAYLOAD_MASS,
+            inertia=DEFAULT_QUAD_INERTIA,
+            cable_length=DEFAULT_CABLE_LENGTH,
+        )
+        assert f2s.mass_q == pytest.approx(DEFAULT_QUAD_MASS)
+        assert f2s.mass_l == pytest.approx(DEFAULT_PAYLOAD_MASS)
+        assert f2s.cable_length == pytest.approx(DEFAULT_CABLE_LENGTH)
+        np.testing.assert_allclose(f2s.inertia, DEFAULT_QUAD_INERTIA)
+
+    def test_from_model_reads_model_params(self):
+        model = QuadrotorCsPayloadBase()
+        f2s = QuadrotorCsPayload.from_model(model)
+        assert f2s.mass_q == pytest.approx(model.mass)
+        assert f2s.mass_l == pytest.approx(model.payload_mass)
+        assert f2s.cable_length == pytest.approx(model.cable_length)
+        np.testing.assert_allclose(f2s.inertia, model.inertia)
+
+    def test_inertia_shape_validated(self):
+        with pytest.raises(ValueError, match="inertia must be 3×3"):
+            QuadrotorCsPayload(inertia=np.zeros((2, 2)))
+
+    def test_cable_length_positive(self):
+        with pytest.raises(ValueError, match="cable_length must be positive"):
+            QuadrotorCsPayload(cable_length=0.0)
+        with pytest.raises(ValueError, match="cable_length must be positive"):
+            QuadrotorCsPayload(cable_length=-1.0)
+
+    def test_class_attribute_triple_declared(self):
+        assert QuadrotorCsPayload.Flats is QuadrotorCsPayloadFlats
+        assert QuadrotorCsPayload.RefState.__name__ == "QuadrotorCsPayloadRefState"
+        assert QuadrotorCsPayload.Inputs.__name__ == "QuadrotorCsPayloadInputs"
+
+
+# ─── QuadrotorCsPayloadFlats validation ───────────────────────────────
+
+
+class TestFlatsValidation:
+    def test_valid_order_flats_construct(self):
+        QuadrotorCsPayloadFlats(
+            x_L=Jet.zeros(order=6, dim=3),
+            psi=Jet.zeros(order=2, dim=1),
+        )
+
+    def test_higher_order_flats_also_accepted(self):
+        QuadrotorCsPayloadFlats(
+            x_L=Jet.zeros(order=8, dim=3),
+            psi=Jet.zeros(order=4, dim=1),
+        )
+
+    def test_x_wrong_dim_rejected(self):
+        with pytest.raises(ValueError, match="x_L must be a 3-D jet"):
+            QuadrotorCsPayloadFlats(
+                x_L=Jet.zeros(order=6, dim=2),
+                psi=Jet.zeros(order=2, dim=1),
+            )
+
+    def test_x_insufficient_order_rejected(self):
+        with pytest.raises(ValueError, match=r"x_L.order must be >= 6"):
+            QuadrotorCsPayloadFlats(
+                x_L=Jet.zeros(order=5, dim=3),
+                psi=Jet.zeros(order=2, dim=1),
+            )
+
+    def test_psi_not_scalar_rejected(self):
+        with pytest.raises(ValueError, match="psi must be a scalar jet"):
+            QuadrotorCsPayloadFlats(
+                x_L=Jet.zeros(order=6, dim=3),
+                psi=Jet.zeros(order=2, dim=3),
+            )
+
+    def test_psi_insufficient_order_rejected(self):
+        with pytest.raises(ValueError, match=r"psi.order must be >= 2"):
+            QuadrotorCsPayloadFlats(
+                x_L=Jet.zeros(order=6, dim=3),
+                psi=Jet.zeros(order=1, dim=1),
+            )
+
+
+# ─── Hover recovery ───────────────────────────────────────────────────
+
+
+class TestHover:
+    @pytest.fixture
+    def f2s(self):
+        return QuadrotorCsPayload(
+            mass_q=DEFAULT_QUAD_MASS,
+            mass_l=DEFAULT_PAYLOAD_MASS,
+            inertia=DEFAULT_QUAD_INERTIA,
+            cable_length=DEFAULT_CABLE_LENGTH,
+        )
+
+    @pytest.fixture
+    def ref_inputs(self, f2s):
+        return f2s.recover(_zero_flats())
+
+    def test_hover_thrust_equals_total_weight(self, ref_inputs):
+        _, inputs = ref_inputs
+        expected = (DEFAULT_QUAD_MASS + DEFAULT_PAYLOAD_MASS) * GRAVITY
+        assert inputs.thrust == pytest.approx(expected, abs=1e-10)
+
+    def test_hover_tension_equals_payload_weight(self, ref_inputs):
+        _, inputs = ref_inputs
+        expected = DEFAULT_PAYLOAD_MASS * GRAVITY
+        assert inputs.tension == pytest.approx(expected, abs=1e-10)
+
+    def test_hover_moment_is_zero(self, ref_inputs):
+        _, inputs = ref_inputs
+        np.testing.assert_allclose(inputs.moment, np.zeros(3), atol=1e-10)
+
+    def test_hover_cable_points_down(self, ref_inputs):
+        ref, _ = ref_inputs
+        np.testing.assert_allclose(
+            np.asarray(ref.cable_attitude), np.array([0.0, 0.0, -1.0]), atol=1e-10
+        )
+
+    def test_hover_quadrotor_above_payload(self, ref_inputs):
+        # x_L = 0, q = -e_3, so x_Q = x_L - ℓ q = +ℓ e_3.
+        ref, _ = ref_inputs
+        np.testing.assert_allclose(
+            ref.position, np.array([0.0, 0.0, DEFAULT_CABLE_LENGTH]), atol=1e-10
+        )
+
+    def test_hover_orientation_is_identity(self, ref_inputs):
+        ref, _ = ref_inputs
+        R = np.asarray(ref.orientation)
+        err = np.linalg.norm(R - np.eye(3), ord="fro")
+        assert err == pytest.approx(0.0, abs=1e-10)
+
+    def test_hover_cable_and_body_rates_zero(self, ref_inputs):
+        ref, _ = ref_inputs
+        np.testing.assert_allclose(ref.cable_angular_velocity, np.zeros(3), atol=1e-10)
+        np.testing.assert_allclose(ref.cable_angular_acceleration, np.zeros(3), atol=1e-10)
+        np.testing.assert_allclose(np.asarray(ref.angular_velocity), np.zeros(3), atol=1e-10)
+        np.testing.assert_allclose(ref.angular_acceleration, np.zeros(3), atol=1e-10)
+
+
+# ─── Pure yaw-rate recovery ───────────────────────────────────────────
+
+
+class TestPureYawRate:
+    """Hover with yaw rate — payload stays still, quadrotor spins about world e_3."""
+
+    @pytest.fixture
+    def f2s(self):
+        return QuadrotorCsPayload()
+
+    @pytest.fixture
+    def ref_inputs(self, f2s):
+        x_jet = Jet.zeros(order=6, dim=3)
+        psi_jet = Jet(np.array([0.0, 0.5, 0.0]))
+        return f2s.recover(QuadrotorCsPayloadFlats(x_L=x_jet, psi=psi_jet))
+
+    def test_angular_velocity_matches_yaw_rate(self, ref_inputs):
+        ref, _ = ref_inputs
+        Omega = np.asarray(ref.angular_velocity)
+        np.testing.assert_allclose(Omega[:2], np.zeros(2), atol=1e-10)
+        assert Omega[2] == pytest.approx(0.5, abs=1e-10)
+
+    def test_orientation_at_t0_is_identity(self, ref_inputs):
+        ref, _ = ref_inputs
+        np.testing.assert_allclose(np.asarray(ref.orientation), np.eye(3), atol=1e-10)
+
+    def test_cable_stays_vertical_under_pure_yaw(self, ref_inputs):
+        # Yawing the quadrotor about e_3 with the payload at origin should
+        # leave the cable pointing straight down — no swing.
+        ref, _ = ref_inputs
+        np.testing.assert_allclose(
+            np.asarray(ref.cable_attitude), np.array([0.0, 0.0, -1.0]), atol=1e-10
+        )
+        np.testing.assert_allclose(ref.cable_angular_velocity, np.zeros(3), atol=1e-10)
+
+
+# ─── Yaw with non-zero second derivative ──────────────────────────────
+
+
+class TestYawWithAcceleration:
+    @pytest.fixture
+    def f2s(self):
+        return QuadrotorCsPayload()
+
+    @pytest.fixture
+    def ref_inputs(self, f2s):
+        x_jet = Jet.zeros(order=6, dim=3)
+        psi_jet = Jet(np.array([0.0, 0.5, 0.3]))
+        return f2s.recover(QuadrotorCsPayloadFlats(x_L=x_jet, psi=psi_jet))
+
+    def test_angular_acceleration_matches_yaw_accel(self, ref_inputs):
+        ref, _ = ref_inputs
+        dOmega = np.asarray(ref.angular_acceleration)
+        np.testing.assert_allclose(dOmega[:2], np.zeros(2), atol=1e-10)
+        assert dOmega[2] == pytest.approx(0.3, abs=1e-10)
+
+    def test_moment_yaw_axis(self, ref_inputs):
+        _, inputs = ref_inputs
+        np.testing.assert_allclose(inputs.moment[:2], np.zeros(2), atol=1e-10)
+        Jzz = DEFAULT_QUAD_INERTIA[2, 2]
+        assert inputs.moment[2] == pytest.approx(Jzz * 0.3, abs=1e-10)
+
+
+# ─── Singularities ────────────────────────────────────────────────────
+
+
+class TestSingularities:
+    def test_payload_free_fall_raises(self):
+        f2s = QuadrotorCsPayload()
+        # ẍ_L + g e_3 = 0 — payload in free fall, cable goes slack.
+        x_data = np.zeros((7, 3))
+        x_data[2] = np.array([0.0, 0.0, -GRAVITY])
+        with pytest.raises(ValueError, match="payload is in free fall"):
+            f2s.recover(
+                QuadrotorCsPayloadFlats(
+                    x_L=Jet(x_data),
+                    psi=Jet.zeros(order=2, dim=1),
+                )
+            )
+
+
+# ─── Cable kinematic consistency ──────────────────────────────────────
+
+
+class TestCableConsistency:
+    """Recovered (q, ω, q̇) should satisfy the constraints
+    ‖q‖ = 1, ω · q = 0, and q̇ = ω × q at every recovered point."""
+
+    @pytest.fixture
+    def f2s(self):
+        return QuadrotorCsPayload()
+
+    @pytest.mark.parametrize("t", [0.0, 0.13, 0.79, 1.5])
+    def test_q_unit_norm(self, f2s, t):
+        ref, _ = f2s.recover(_circle_flats(t))
+        q = np.asarray(ref.cable_attitude)
+        assert np.linalg.norm(q) == pytest.approx(1.0, abs=1e-10)
+
+    @pytest.mark.parametrize("t", [0.0, 0.13, 0.79, 1.5])
+    def test_omega_perpendicular_to_q(self, f2s, t):
+        ref, _ = f2s.recover(_circle_flats(t))
+        q = np.asarray(ref.cable_attitude)
+        omega = np.asarray(ref.cable_angular_velocity)
+        assert q.dot(omega) == pytest.approx(0.0, abs=1e-10)
+
+    @pytest.mark.parametrize("t", [0.0, 0.13, 0.79, 1.5])
+    def test_quadrotor_position_matches_payload_minus_cable(self, f2s, t):
+        ref, _ = f2s.recover(_circle_flats(t))
+        L = f2s.cable_length
+        expected = ref.payload_position - L * np.asarray(ref.cable_attitude)
+        np.testing.assert_allclose(ref.position, expected, atol=1e-12)
+
+
+# ─── Round-trip with the model ────────────────────────────────────────
+
+
+class TestRoundTrip:
+    """Recover (ref, inputs) from analytic flats, step the cspayload model
+    with the feedforward wrench, and confirm tracking against the analytic
+    reference at the next sample."""
+
+    @pytest.fixture
+    def f2s(self):
+        return QuadrotorCsPayload()
+
+    @pytest.fixture
+    def model(self):
+        return QuadrotorCsPayloadBase(input="wrench")
+
+    def test_one_step_tracks_analytic_reference(self, f2s, model):
+        flats0 = _circle_flats(0.0)
+        ref0, u0 = f2s.recover(flats0)
+        state0 = ref0.as_state()
+        model.reset(
+            payload_position=state0.payload_position,
+            payload_velocity=state0.payload_velocity,
+            cable_attitude=state0.cable_attitude,
+            cable_angular_velocity=state0.cable_angular_velocity,
+            orientation=state0.orientation,
+            angular_velocity=state0.angular_velocity,
+        )
+
+        u = np.array([u0.thrust, *u0.moment])
+        model.step(u)
+
+        flats1 = _circle_flats(model.t)
+        ref1, _ = f2s.recover(flats1)
+
+        # ZOH over 5 ms, smooth trajectory: tight tracking.
+        np.testing.assert_allclose(model.state.payload_position, ref1.payload_position, atol=1e-3)
+        np.testing.assert_allclose(model.state.payload_velocity, ref1.payload_velocity, atol=1e-3)
+
+        R_sim = np.asarray(model.state.orientation)
+        R_ref = np.asarray(ref1.orientation)
+        att_err = np.linalg.norm(R_sim - R_ref, ord="fro")
+        assert att_err < 1e-2
+
+    def test_two_steps_tracks_analytic_reference(self, f2s, model):
+        flats0 = _circle_flats(0.0)
+        ref0, _ = f2s.recover(flats0)
+        state0 = ref0.as_state()
+        model.reset(
+            payload_position=state0.payload_position,
+            payload_velocity=state0.payload_velocity,
+            cable_attitude=state0.cable_attitude,
+            cable_angular_velocity=state0.cable_angular_velocity,
+            orientation=state0.orientation,
+            angular_velocity=state0.angular_velocity,
+        )
+
+        for _ in range(2):
+            flats_t = _circle_flats(model.t)
+            _, u_t = f2s.recover(flats_t)
+            model.step(np.array([u_t.thrust, *u_t.moment]))
+
+        flats_end = _circle_flats(model.t)
+        ref_end, _ = f2s.recover(flats_end)
+        np.testing.assert_allclose(
+            model.state.payload_position, ref_end.payload_position, atol=1e-2
+        )
+        np.testing.assert_allclose(
+            model.state.payload_velocity, ref_end.payload_velocity, atol=1e-2
+        )

--- a/tests/flatness/test_quadrotor_cspayload_feedforward.py
+++ b/tests/flatness/test_quadrotor_cspayload_feedforward.py
@@ -1,0 +1,369 @@
+"""Open-loop feedforward tracking tests for the cspayload flat-to-state map.
+
+The flat-output-derived (f, M) is fed straight into the wrench-input
+dynamics of the quadrotor + cable-suspended payload model — no closed-loop
+controller. Tracking error after a finite horizon should be bounded by the
+integrator's residual.
+
+Two integrators are exercised:
+  - The shipped ZOH-Euler in QuadrotorCsPayloadBase (h = 1.25 ms inner step,
+    feedforward held constant across the 5 ms outer step).
+  - A high-order adaptive RK (DOP853 via scipy.integrate.solve_ivp)
+    re-evaluating (f, M) continuously and using a quaternion attitude
+    parameterisation. Drives integrator error effectively to round-off, so
+    any non-zero residue is direct evidence of a flat-to-state formula bug.
+
+The 14-D cspayload state is laid out for DOP853 as
+    y = [x_L (3), v_L (3), q (3), ω (3), q_wxyz (4), Ω (3)]   (19D)
+with q ∈ S² and ω · q = 0 enforced by the dynamics; the quaternion is
+re-normalised at every RHS call to absorb round-off.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from scipy.integrate import solve_ivp
+from scipy.spatial.transform import Rotation as _ScipyRot
+
+from udaan.core.defaults import (
+    DEFAULT_CABLE_LENGTH,
+    DEFAULT_PAYLOAD_MASS,
+    DEFAULT_QUAD_INERTIA,
+    DEFAULT_QUAD_MASS,
+    GRAVITY,
+)
+from udaan.flatness import (
+    Jet,
+    QuadrotorCsPayload,
+    QuadrotorCsPayloadFlats,
+)
+from udaan.manif import SO3
+from udaan.models.quadrotor_cspayload.base import QuadrotorCsPayloadBase
+
+TF = 5.0
+
+
+# ─── Trajectory builders ──────────────────────────────────────────────
+
+
+def hover_flats(t: float) -> QuadrotorCsPayloadFlats:
+    """Stationary hover: payload at [0, 0, 0]; quadrotor sits at [0, 0, ℓ]."""
+    x_data = np.zeros((7, 3))
+    psi_data = np.zeros(3)
+    return QuadrotorCsPayloadFlats(x_L=Jet(x_data), psi=Jet(psi_data))
+
+
+def circle_flats(
+    t: float, r: float = 0.4, omega: float = 1.0, z0: float = 0.0
+) -> QuadrotorCsPayloadFlats:
+    """Payload circle in the XY plane at height z0; yaw tracks heading angle ωt.
+
+    Radius and angular speed are kept modest so the cable stays well clear of
+    its slack-cable singularity (T > 0) and the swing angle is moderate.
+    """
+    c, s = np.cos(omega * t), np.sin(omega * t)
+    x_data = np.array(
+        [
+            [r * c, r * s, z0],
+            [-r * omega * s, r * omega * c, 0.0],
+            [-r * omega**2 * c, -r * omega**2 * s, 0.0],
+            [r * omega**3 * s, -r * omega**3 * c, 0.0],
+            [r * omega**4 * c, r * omega**4 * s, 0.0],
+            [-r * omega**5 * s, r * omega**5 * c, 0.0],
+            [-r * omega**6 * c, -r * omega**6 * s, 0.0],
+        ]
+    )
+    psi_data = np.array([omega * t, omega, 0.0])
+    return QuadrotorCsPayloadFlats(x_L=Jet(x_data), psi=Jet(psi_data))
+
+
+# ─── Harness ──────────────────────────────────────────────────────────
+
+
+def _f2s_default() -> QuadrotorCsPayload:
+    return QuadrotorCsPayload(
+        mass_q=DEFAULT_QUAD_MASS,
+        mass_l=DEFAULT_PAYLOAD_MASS,
+        inertia=DEFAULT_QUAD_INERTIA,
+        cable_length=DEFAULT_CABLE_LENGTH,
+    )
+
+
+def _seed_model(model: QuadrotorCsPayloadBase, ref) -> None:
+    state = ref.as_state()
+    model.reset(
+        payload_position=np.asarray(state.payload_position).copy(),
+        payload_velocity=np.asarray(state.payload_velocity).copy(),
+        cable_attitude=state.cable_attitude,
+        cable_angular_velocity=state.cable_angular_velocity,
+        orientation=state.orientation,
+        angular_velocity=state.angular_velocity,
+    )
+
+
+def _final_errors(model: QuadrotorCsPayloadBase, ref_final) -> dict:
+    """Errors of the model state vs. the analytic flat reference at model.t."""
+    pos_L = float(np.linalg.norm(model.state.payload_position - ref_final.payload_position))
+    vel_L = float(np.linalg.norm(model.state.payload_velocity - ref_final.payload_velocity))
+    q_err = float(
+        np.linalg.norm(
+            np.asarray(model.state.cable_attitude) - np.asarray(ref_final.cable_attitude)
+        )
+    )
+    om_cable_err = float(
+        np.linalg.norm(
+            np.asarray(model.state.cable_angular_velocity) - ref_final.cable_angular_velocity
+        )
+    )
+    att_err = float(SO3(np.asarray(ref_final.orientation)).config_error(model.state.orientation))
+    om_err = float(
+        np.linalg.norm(
+            np.asarray(model.state.angular_velocity) - np.asarray(ref_final.angular_velocity)
+        )
+    )
+    return {
+        "payload_pos": pos_L,
+        "payload_vel": vel_L,
+        "cable_q": q_err,
+        "cable_omega": om_cable_err,
+        "attitude": att_err,
+        "body_omega": om_err,
+    }
+
+
+def _run_open_loop(flats_of_t, tf: float = TF) -> dict:
+    """Seed the model from the t=0 reference, march with pure feedforward,
+    return final-state errors against the flat reference at tf."""
+    f2s = _f2s_default()
+    model = QuadrotorCsPayloadBase(input="wrench")
+
+    ref0, _ = f2s.recover(flats_of_t(0.0))
+    _seed_model(model, ref0)
+
+    while model.t < tf - 1e-9:
+        _, inputs = f2s.recover(flats_of_t(model.t))
+        u = np.array([inputs.thrust, *inputs.moment])
+        model.step(u)
+
+    ref_final, _ = f2s.recover(flats_of_t(tf))
+    return _final_errors(model, ref_final)
+
+
+# ─── Tests ────────────────────────────────────────────────────────────
+
+
+class TestOpenLoopHover:
+    def test_tracking_error_is_purely_numerical(self):
+        e = _run_open_loop(hover_flats)
+
+        # Pure-feedforward hover with exact thrust = (m_Q + m_L) g and
+        # zero moment: the dynamics should stay perfectly stationary up
+        # to machine epsilon.
+        assert e["payload_pos"] < 1e-10, f"payload pos drift {e['payload_pos']:.2e} m"
+        assert e["payload_vel"] < 1e-10, f"payload vel drift {e['payload_vel']:.2e} m/s"
+        assert e["cable_q"] < 1e-10, f"cable q drift {e['cable_q']:.2e}"
+        assert e["cable_omega"] < 1e-10, f"cable ω drift {e['cable_omega']:.2e} rad/s"
+        assert e["attitude"] < 1e-10, f"attitude drift {e['attitude']:.2e}"
+        assert e["body_omega"] < 1e-10, f"body Ω drift {e['body_omega']:.2e} rad/s"
+
+
+class TestOpenLoopCircle:
+    def test_tracking_error_is_purely_numerical(self):
+        e = _run_open_loop(circle_flats)
+
+        # ZOH-Euler at h = 1.25 ms over TF s. Generous bounds (~10× the
+        # single-quadrotor tolerance, since the cable adds two
+        # integration paths and S²/TS² subspace projection).
+        assert e["payload_pos"] < 5e-2, f"payload pos {e['payload_pos']:.2e} m"
+        assert e["payload_vel"] < 5e-2, f"payload vel {e['payload_vel']:.2e} m/s"
+        assert e["cable_q"] < 5e-2, f"cable q {e['cable_q']:.2e}"
+        assert e["cable_omega"] < 5e-2, f"cable ω {e['cable_omega']:.2e} rad/s"
+        assert e["attitude"] < 5e-2, f"attitude {e['attitude']:.2e}"
+        assert e["body_omega"] < 5e-2, f"body Ω {e['body_omega']:.2e} rad/s"
+
+
+# ─── High-order ODE integration (DOP853 + quaternion attitude) ────────
+
+
+def _cspayload_rhs(t, y, m_Q, m_L, L, J, J_inv, flats_of_t, f2s):
+    """Full cspayload ODE in the 19-D layout
+        y = [x_L, v_L, q, ω, q_wxyz, Ω].
+
+    Re-evaluates the flat-to-state feedforward (f, M) at the *exact*
+    current t — strictly tighter than the ZOH path. The S² / TS²
+    constraints (‖q‖ = 1, ω · q = 0) are preserved exactly by the
+    continuous-time dynamics; small numerical drift is absorbed by
+    re-normalising q and re-projecting ω each call.
+    """
+    x_L = y[0:3]
+    v_L = y[3:6]
+    q = y[6:9]
+    omega = y[9:12]
+    q_wxyz = y[12:16]
+    Omega = y[16:19]
+
+    # Numerical hygiene: re-project onto S² / T_q S² / unit-quaternion.
+    q = q / np.linalg.norm(q)
+    omega = omega - q * (omega.dot(q))
+    q_wxyz = q_wxyz / np.linalg.norm(q_wxyz)
+
+    R = _ScipyRot.from_quat(
+        [q_wxyz[1], q_wxyz[2], q_wxyz[3], q_wxyz[0]]  # scipy uses xyzw
+    ).as_matrix()
+
+    _, inputs = f2s.recover(flats_of_t(t))
+    f = inputs.thrust
+    M = inputs.moment
+
+    e3 = np.array([0.0, 0.0, 1.0])
+    fRe3 = f * (R @ e3)
+    g_e3 = GRAVITY * e3
+
+    # Translational payload dynamics:
+    #   (m_Q + m_L)(v̇_L + g e_3) = (q · fRe3 - m_Q L ‖ω‖²) q
+    # (using ‖q̇‖² = ‖ω × q‖² = ‖ω‖² for ω ⊥ q, ‖q‖ = 1)
+    omega_sq = float(omega.dot(omega))
+    scalar = (q.dot(fRe3) - m_Q * L * omega_sq) / (m_Q + m_L)
+    v_L_dot = -g_e3 + scalar * q
+
+    # Cable kinematics:  q̇ = ω × q
+    q_dot = np.cross(omega, q)
+
+    # Cable angular dynamics:  m_Q L ω̇ = -q × fRe3
+    omega_dot = -np.cross(q, fRe3) / (m_Q * L)
+
+    # Quaternion kinematics:  q̇ = ½ q ⊗ [0, Ω]   (Hamilton, scalar-first)
+    w, x, y_, z = q_wxyz
+    p_, q_, r_ = Omega
+    q_quat_dot = 0.5 * np.array(
+        [
+            -x * p_ - y_ * q_ - z * r_,
+            w * p_ - z * q_ + y_ * r_,
+            z * p_ + w * q_ - x * r_,
+            -y_ * p_ + x * q_ + w * r_,
+        ]
+    )
+
+    # Body-rate dynamics:  J Ω̇ = M - Ω × J Ω
+    Omega_dot = J_inv @ (M - np.cross(Omega, J @ Omega))
+
+    return np.concatenate([v_L, v_L_dot, q_dot, omega_dot, q_quat_dot, Omega_dot])
+
+
+def _run_high_order(flats_of_t, tf: float = TF) -> dict:
+    """Same harness as `_run_open_loop`, but integrate with adaptive DOP853
+    (8th-order RK with adaptive step). Tight tolerances drive integrator
+    error to round-off, isolating any flat-to-state formula error in the
+    residual."""
+    f2s = _f2s_default()
+    m_Q = DEFAULT_QUAD_MASS
+    m_L = DEFAULT_PAYLOAD_MASS
+    L = DEFAULT_CABLE_LENGTH
+    J = np.asarray(DEFAULT_QUAD_INERTIA, dtype=float)
+    J_inv = np.linalg.inv(J)
+
+    ref0, _ = f2s.recover(flats_of_t(0.0))
+    R0 = np.asarray(ref0.orientation)
+    q0_xyzw = _ScipyRot.from_matrix(R0).as_quat()
+    q0_wxyz = np.array([q0_xyzw[3], q0_xyzw[0], q0_xyzw[1], q0_xyzw[2]])
+
+    y0 = np.concatenate(
+        [
+            np.asarray(ref0.payload_position),
+            np.asarray(ref0.payload_velocity),
+            np.asarray(ref0.cable_attitude),
+            np.asarray(ref0.cable_angular_velocity),
+            q0_wxyz,
+            np.asarray(ref0.angular_velocity),
+        ]
+    )
+
+    sol = solve_ivp(
+        _cspayload_rhs,
+        (0.0, tf),
+        y0,
+        method="DOP853",
+        rtol=1e-12,
+        atol=1e-12,
+        args=(m_Q, m_L, L, J, J_inv, flats_of_t, f2s),
+        dense_output=False,
+    )
+    assert sol.success, f"DOP853 failed: {sol.message}"
+
+    yf = sol.y[:, -1]
+    ref_final, _ = f2s.recover(flats_of_t(tf))
+
+    # Reconstruct sim quantities for the same comparison shape as ZOH.
+    q_sim = yf[6:9] / np.linalg.norm(yf[6:9])
+    om_cable_sim = yf[9:12]
+    om_cable_sim = om_cable_sim - q_sim * om_cable_sim.dot(q_sim)
+    q_wxyz = yf[12:16] / np.linalg.norm(yf[12:16])
+    R_sim = _ScipyRot.from_quat([q_wxyz[1], q_wxyz[2], q_wxyz[3], q_wxyz[0]]).as_matrix()
+
+    payload_pos = float(np.linalg.norm(yf[0:3] - ref_final.payload_position))
+    payload_vel = float(np.linalg.norm(yf[3:6] - ref_final.payload_velocity))
+    cable_q = float(np.linalg.norm(q_sim - np.asarray(ref_final.cable_attitude)))
+    cable_omega = float(np.linalg.norm(om_cable_sim - ref_final.cable_angular_velocity))
+    attitude = float(SO3(np.asarray(ref_final.orientation)).config_error(SO3(R_sim)))
+    body_omega = float(np.linalg.norm(yf[16:19] - np.asarray(ref_final.angular_velocity)))
+
+    return {
+        "payload_pos": payload_pos,
+        "payload_vel": payload_vel,
+        "cable_q": cable_q,
+        "cable_omega": cable_omega,
+        "attitude": attitude,
+        "body_omega": body_omega,
+    }
+
+
+class TestOpenLoopCircleHighOrder:
+    """The circle test, re-run with DOP853 + quaternion attitude.
+
+    Errors should drop several orders of magnitude vs. the ZOH-Euler
+    version — confirming that the residual ZOH error is integrator
+    noise, not a flat-to-state formula bug.
+    """
+
+    def test_high_order_drives_error_to_roundoff(self):
+        e = _run_high_order(circle_flats)
+        # DOP853 at rtol=atol=1e-12 should drive payload position drift
+        # to sub-µm and attitude drift to round-off. Bounds are generous
+        # (~3 orders of magnitude above expected) to leave headroom.
+        assert e["payload_pos"] < 1e-6, f"payload pos {e['payload_pos']:.2e} m"
+        assert e["payload_vel"] < 1e-6, f"payload vel {e['payload_vel']:.2e} m/s"
+        assert e["cable_q"] < 1e-7, f"cable q {e['cable_q']:.2e}"
+        assert e["cable_omega"] < 1e-7, f"cable ω {e['cable_omega']:.2e} rad/s"
+        assert e["attitude"] < 1e-9, f"attitude {e['attitude']:.2e}"
+        assert e["body_omega"] < 1e-9, f"body Ω {e['body_omega']:.2e} rad/s"
+
+
+# ─── Diagnostic — run with `pytest -s` to print the actual numbers ────
+
+
+@pytest.mark.parametrize("name,builder", [("hover", hover_flats), ("circle", circle_flats)])
+def test_print_errors_zoh(name, builder):
+    e = _run_open_loop(builder)
+    print(
+        f"\n  [{name}] ZOH-Euler errors @ t={TF:.1f}s:"
+        f"\n    payload pos : {e['payload_pos']:.3e} m"
+        f"\n    payload vel : {e['payload_vel']:.3e} m/s"
+        f"\n    cable q     : {e['cable_q']:.3e}"
+        f"\n    cable ω     : {e['cable_omega']:.3e} rad/s"
+        f"\n    attitude Ψ  : {e['attitude']:.3e}"
+        f"\n    body Ω      : {e['body_omega']:.3e} rad/s"
+    )
+
+
+def test_print_errors_dop853_circle():
+    e = _run_high_order(circle_flats)
+    print(
+        f"\n  [circle, DOP853 rtol=atol=1e-12] errors @ t={TF:.1f}s:"
+        f"\n    payload pos : {e['payload_pos']:.3e} m"
+        f"\n    payload vel : {e['payload_vel']:.3e} m/s"
+        f"\n    cable q     : {e['cable_q']:.3e}"
+        f"\n    cable ω     : {e['cable_omega']:.3e} rad/s"
+        f"\n    attitude Ψ  : {e['attitude']:.3e}"
+        f"\n    body Ω      : {e['body_omega']:.3e} rad/s"
+    )

--- a/udaan/flatness/__init__.py
+++ b/udaan/flatness/__init__.py
@@ -9,6 +9,10 @@ Per-system maps
 ---------------
 :class:`Quadrotor` — flat-to-state recovery for a rigid-body quadrotor
 with flat output ``(x_Q, ψ)``.
+
+:class:`QuadrotorCsPayload` — flat-to-state recovery for a quadrotor
+with a cable-suspended point-mass payload, with flat output
+``(x_L, ψ)``.
 """
 
 from .base import Flat2State as Flat2State
@@ -25,11 +29,27 @@ from .quadrotor import (
 from .quadrotor import (
     QuadrotorRefState as QuadrotorRefState,
 )
+from .quadrotor_cspayload import (
+    QuadrotorCsPayload as QuadrotorCsPayload,
+)
+from .quadrotor_cspayload import (
+    QuadrotorCsPayloadFlats as QuadrotorCsPayloadFlats,
+)
+from .quadrotor_cspayload import (
+    QuadrotorCsPayloadInputs as QuadrotorCsPayloadInputs,
+)
+from .quadrotor_cspayload import (
+    QuadrotorCsPayloadRefState as QuadrotorCsPayloadRefState,
+)
 
 __all__ = [
     "Flat2State",
     "Jet",
     "Quadrotor",
+    "QuadrotorCsPayload",
+    "QuadrotorCsPayloadFlats",
+    "QuadrotorCsPayloadInputs",
+    "QuadrotorCsPayloadRefState",
     "QuadrotorFlats",
     "QuadrotorInputs",
     "QuadrotorRefState",

--- a/udaan/flatness/quadrotor_cspayload.py
+++ b/udaan/flatness/quadrotor_cspayload.py
@@ -1,0 +1,349 @@
+"""Differential flatness for a quadrotor with a cable-suspended point-mass payload.
+
+Flat output::
+
+    y = (x_L, ψ)
+
+where x_L ∈ R^3 is the payload position and ψ ∈ R is the quadrotor yaw.
+
+Derivative orders required::
+
+    x_L through pop  (x_L, ẋ_L, ẍ_L, x_L^(3), x_L^(4), x_L^(5), x_L^(6))
+    ψ   through ψ̈    (ψ, ψ̇, ψ̈)
+
+The map recovers the full state (x_L, ẋ_L, q, ω, x_Q, ẋ_Q, R, Ω) plus the
+feedforward thrust and moment (f, M).
+
+The cable unit vector ``q`` points from the quadrotor to the payload —
+codebase convention; matches ``QuadrotorCsPayloadState.cable_attitude``,
+whose default ``[0, 0, -1]`` places the payload directly below the
+quadrotor at rest.
+
+Reference:
+    K. Sreenath, N. Michael, V. Kumar, "Trajectory Generation and
+    Control of a Quadrotor with a Cable-Suspended Load — A
+    Differentially-Flat Hybrid System", IEEE ICRA, 2013.
+    (Companion: K. Sreenath, T. Lee, V. Kumar, "Geometric Control and
+    Differential Flatness of a Quadrotor UAV with a Cable-Suspended
+    Load", 52nd IEEE CDC, 2013.)
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from math import comb
+
+import numpy as np
+
+from ..core.defaults import (
+    DEFAULT_CABLE_LENGTH,
+    DEFAULT_PAYLOAD_MASS,
+    DEFAULT_QUAD_INERTIA,
+    DEFAULT_QUAD_MASS,
+    GRAVITY,
+)
+from ..core.types import Mat3, Vec3
+from ..manif import S2, SO3, TS2, TSO3
+from .base import Flat2State
+from .jet import Jet
+from .quadrotor import _attitude_from_thrust_vector
+
+_E3 = np.array([0.0, 0.0, 1.0])
+
+
+def _zeros3() -> Vec3:
+    return np.zeros(3)
+
+
+def _normalize_derivatives(v: list[np.ndarray]) -> tuple[list[float], list[np.ndarray]]:
+    """Given the time-derivative tuple ``v = [v, v̇, v̈, …, v^(K)]`` of a
+    non-vanishing vector signal, return ``(n, u)`` where ``n[k] = (d/dt)^k ‖v‖``
+    and ``u[k] = (d/dt)^k (v / ‖v‖)`` for k = 0, 1, …, K.
+
+    Uses the Leibniz expansions
+        (n²)^(k) = sum_{j=0}^{k} C(k,j) v^(j) · v^(k-j),
+        u^(k)   = (v^(k) - sum_{j=1}^{k} C(k,j) n^(j) u^(k-j)) / n,
+    and the closed-form recursion for n^(k) by differentiating ``n² = n·n``.
+
+    Raises ``ValueError`` on a vanishing v (free-fall singularity in the
+    flatness map).
+    """
+    K = len(v) - 1
+    n_val = float(np.linalg.norm(v[0]))
+    if n_val < 1e-9:
+        raise ValueError(
+            "_normalize_derivatives: input vector has zero norm — singularity in the flatness map."
+        )
+
+    # n²[k] := (d/dt)^k (‖v‖²)
+    n_sq = []
+    for k in range(K + 1):
+        s = np.zeros_like(v[0], dtype=float)[..., 0] if False else 0.0
+        s = 0.0
+        for j in range(k + 1):
+            s += comb(k, j) * float(v[j].dot(v[k - j]))
+        n_sq.append(s)
+
+    # n[k] from the Leibniz expansion of (n·n) = n²:
+    #   (n²)^(k) = sum_{j=0}^{k} C(k,j) n^(j) n^(k-j)
+    #   2 n n^(k) = (n²)^(k) - sum_{j=1}^{k-1} C(k,j) n^(j) n^(k-j)
+    n = [n_val]
+    for k in range(1, K + 1):
+        s = n_sq[k]
+        for j in range(1, k):
+            s -= comb(k, j) * n[j] * n[k - j]
+        n.append(s / (2.0 * n_val))
+
+    # u[k] from u·n = v:
+    #   v^(k) = sum_{j=0}^{k} C(k,j) u^(j) n^(k-j)
+    #   u^(k) = (v^(k) - sum_{j=1}^{k} C(k,j) n^(j) u^(k-j)) / n
+    u = [v[0] / n_val]
+    for k in range(1, K + 1):
+        s = v[k].copy()
+        for j in range(1, k + 1):
+            s -= comb(k, j) * n[j] * u[k - j]
+        u.append(s / n_val)
+
+    return n, u
+
+
+def cable_direction_jet(
+    payload_accel: list[np.ndarray], mass_l: float, gravity: float = GRAVITY
+) -> tuple[list[float], list[np.ndarray]]:
+    """Cable tension and unit-direction jets from the payload-acceleration jet.
+
+    Newton's law on the point-mass payload gives the cable force
+    ``T q = -m_L (a_L + g e3)``, where ``q`` is the unit cable direction
+    (quadrotor → payload).  Given ``payload_accel = [a_L, ȧ_L, …, a_L^(K)]``,
+    return ``(T, q)`` where ``T[k] = (d/dt)^k T`` is the k-th derivative of the
+    scalar cable tension and ``q[k] = (d/dt)^k q`` for k = 0…K, via the Leibniz
+    :func:`_normalize_derivatives` chain.
+
+    Raises ``ValueError`` if the payload is in free fall (``a_L + g e3 ≈ 0``):
+    the cable goes slack and ``q`` is undefined.
+    """
+    tvec = [-mass_l * (payload_accel[0] + gravity * _E3)]
+    for k in range(1, len(payload_accel)):
+        tvec.append(-mass_l * payload_accel[k])
+    return _normalize_derivatives(tvec)
+
+
+@dataclass
+class QuadrotorCsPayloadFlats:
+    """Flat output of a quadrotor with cable-suspended payload: payload-position
+    jet (order ≥ 6) and yaw-angle jet (order ≥ 2).
+
+    Attributes:
+        x_L:  dim-3 :class:`Jet` of the payload position, with derivatives
+              through pop (order ≥ 6) — ``q^(4)`` and hence the moment
+              feedforward consume the 6th derivative of ``x_L``.
+        psi:  scalar :class:`Jet` of the yaw angle, with derivatives through
+              yaw acceleration (order ≥ 2).
+    """
+
+    x_L: Jet  # dim 3, order >= 6 (through pop)
+    psi: Jet  # dim 1 scalar, order >= 2 (through ψ̈)
+
+    def __post_init__(self):
+        if self.x_L.dim != 3:
+            raise ValueError(f"x_L must be a 3-D jet; got dim={self.x_L.dim}")
+        if self.x_L.order < 6:
+            raise ValueError(f"x_L.order must be >= 6 (pop); got {self.x_L.order}")
+        if not self.psi.is_scalar:
+            raise ValueError(f"psi must be a scalar jet; got dim={self.psi.dim}")
+        if self.psi.order < 2:
+            raise ValueError(f"psi.order must be >= 2; got {self.psi.order}")
+
+
+@dataclass
+class QuadrotorCsPayloadRefState:
+    """Recovered kinematic reference state for a quadrotor with cable-suspended
+    payload.
+
+    Field naming mirrors :class:`udaan.models.quadrotor_cspayload.base.QuadrotorCsPayloadState`
+    where the two overlap; ``acceleration``, ``payload_acceleration``, and
+    ``angular_acceleration`` are extras that the flatness map also produces.
+    """
+
+    # Payload kinematics
+    payload_position: Vec3 = field(default_factory=_zeros3)
+    payload_velocity: Vec3 = field(default_factory=_zeros3)
+    payload_acceleration: Vec3 = field(default_factory=_zeros3)
+
+    # Quadrotor centre-of-mass kinematics
+    position: Vec3 = field(default_factory=_zeros3)
+    velocity: Vec3 = field(default_factory=_zeros3)
+    acceleration: Vec3 = field(default_factory=_zeros3)
+
+    # Cable kinematics — q is a unit 3-vector, ω its angular velocity on T_q S^2
+    cable_attitude: Vec3 = field(default_factory=lambda: np.array([0.0, 0.0, -1.0]))
+    cable_angular_velocity: Vec3 = field(default_factory=_zeros3)
+    cable_angular_acceleration: Vec3 = field(default_factory=_zeros3)
+
+    # Quadrotor attitude
+    orientation: SO3 = field(default_factory=SO3)
+    angular_velocity: TSO3 = field(default_factory=TSO3)
+    angular_acceleration: Vec3 = field(default_factory=_zeros3)
+
+    def as_state(self):
+        """Project onto the model's ``QuadrotorCsPayloadState`` shape (drops
+        all ``*_acceleration`` extras; wraps cable fields as :class:`S2`/:class:`TS2`)."""
+        from ..models.quadrotor_cspayload.base import QuadrotorCsPayloadState
+
+        return QuadrotorCsPayloadState(
+            position=self.position,
+            velocity=self.velocity,
+            orientation=self.orientation,
+            angular_velocity=self.angular_velocity,
+            payload_position=self.payload_position,
+            payload_velocity=self.payload_velocity,
+            cable_attitude=S2(np.asarray(self.cable_attitude)),
+            cable_angular_velocity=TS2(np.asarray(self.cable_angular_velocity)),
+        )
+
+
+@dataclass
+class QuadrotorCsPayloadInputs:
+    """Feedforward inputs recovered from the flat output.
+
+    Attributes:
+        thrust:   collective thrust magnitude ``f``.
+        moment:   body-frame moment ``M``.
+        tension:  cable tension ``T = m_L ‖ẍ_L + g e_3‖``. Falls out of the
+                  Newton–Euler form of Step 1 in the recovery; useful as a
+                  slack-cable diagnostic (``T → 0`` marks the hybrid-mode
+                  boundary at which the cable goes slack).
+    """
+
+    thrust: float = 0.0
+    moment: Vec3 = field(default_factory=_zeros3)
+    tension: float = 0.0
+
+
+class QuadrotorCsPayload(Flat2State):
+    """Differential-flatness recovery for a quadrotor with a cable-suspended,
+    point-mass payload (taut cable, single rigid-body quadrotor)."""
+
+    Flats = QuadrotorCsPayloadFlats
+    RefState = QuadrotorCsPayloadRefState
+    Inputs = QuadrotorCsPayloadInputs
+
+    def __init__(
+        self,
+        *,
+        mass_q: float = DEFAULT_QUAD_MASS,
+        mass_l: float = DEFAULT_PAYLOAD_MASS,
+        inertia: Mat3 = DEFAULT_QUAD_INERTIA,
+        cable_length: float = DEFAULT_CABLE_LENGTH,
+        gravity: float = GRAVITY,
+    ):
+        self.mass_q = float(mass_q)
+        self.mass_l = float(mass_l)
+        self.inertia = np.asarray(inertia, dtype=float)
+        if self.inertia.shape != (3, 3):
+            raise ValueError(f"inertia must be 3×3, got {self.inertia.shape}")
+        self.cable_length = float(cable_length)
+        if self.cable_length <= 0.0:
+            raise ValueError(f"cable_length must be positive, got {self.cable_length}")
+        self.gravity = float(gravity)
+
+    @classmethod
+    def from_model(cls, model) -> QuadrotorCsPayload:
+        """Build from a :class:`udaan.models.quadrotor_cspayload.QuadrotorCsPayloadBase`-like model."""
+        return cls(
+            mass_q=model.mass,
+            mass_l=model.payload_mass,
+            inertia=model.inertia,
+            cable_length=model.cable_length,
+        )
+
+    def recover(
+        self, flats: QuadrotorCsPayloadFlats
+    ) -> tuple[QuadrotorCsPayloadRefState, QuadrotorCsPayloadInputs]:
+        g = self.gravity
+        mQ = self.mass_q
+        mL = self.mass_l
+        L = self.cable_length
+        J = self.inertia
+
+        # ── Payload-position derivatives, x_L through pop ──────────────
+        x_L = [flats.x_L[k] for k in range(7)]  # rows 0..6
+
+        # ── Newton–Euler on the payload alone: m_L ẍ_L = -T q - m_L g e_3.
+        # The cable force is  T_vec := T q = -m_L (ẍ_L + g e_3); from it
+        #   T = ‖T_vec‖   (scalar cable tension; slack-cable diagnostic),
+        #   q = T_vec / T (unit cable direction, quadrotor → payload),
+        # both with derivatives through order 4 (q^(4) feeds the moment).
+        # The payload acceleration jet is a_L^(k) = x_L^(k+2), i.e. x_L[2:7].
+        if float(np.linalg.norm(mL * (x_L[2] + g * _E3))) < 1e-6:
+            # Payload free-fall: cable goes slack, q is undefined.
+            raise ValueError(
+                "QuadrotorCsPayload.recover: payload is in free fall "
+                "(ẍ_L + g e_3 ≈ 0) — cable would go slack, q undefined."
+            )
+
+        # ── q = T_vec / T and its derivatives through q^(4) ────────────
+        T_derivs, q_d = cable_direction_jet(x_L[2:7], mL, g)
+        tension = T_derivs[0]
+        # q_d[k] is the k-th time derivative of q.
+        q = q_d[0]
+        qdot = q_d[1]
+        qddot = q_d[2]
+        qd3 = q_d[3]
+        qd4 = q_d[4]
+
+        # ── Quadrotor position and its derivatives through snap ────────
+        # x_Q^(k) = x_L^(k) - L q^(k), for k = 0..4.
+        xQ = x_L[0] - L * q
+        vQ = x_L[1] - L * qdot
+        aQ = x_L[2] - L * qddot
+        jQ = x_L[3] - L * qd3
+        sQ = x_L[4] - L * qd4
+
+        # ── Cable angular velocity and acceleration on T_q S² ──────────
+        # ω = q × q̇,  ω̇ = q × q̈   (since q × (ω × q) = ω).
+        omega_cable = np.cross(q, qdot)
+        domega_cable = np.cross(q, qddot)
+
+        # ── Total thrust vector: B = f R e_3 = m_Q (ẍ_Q + g e_3) + m_L (ẍ_L + g e_3).
+        # Sum of the quadrotor and payload Newton's laws (the ±𝐓 cable
+        # reactions cancel); equivalently, B = m_Q (ẍ_Q + g e_3) - 𝐓.
+        B = mQ * (aQ + g * _E3) + mL * (x_L[2] + g * _E3)
+        dB = mQ * jQ + mL * x_L[3]
+        d2B = mQ * sQ + mL * x_L[4]
+
+        if float(np.linalg.norm(B)) < 1e-6:
+            # Quadrotor free-fall — no unique thrust direction.
+            raise ValueError(
+                "QuadrotorCsPayload.recover: net thrust direction is undefined "
+                "(m_Q (ẍ_Q + g e_3) + m_L (ẍ_L + g e_3) ≈ 0)."
+            )
+
+        # ── R, Ω, dΩ, M from (B, ψ) — same machinery as the standalone
+        # quadrotor map; see Steps 2–4 of `quadrotor.md` for the derivation.
+        f, R, Omega, dOmega, moment = _attitude_from_thrust_vector(
+            B,
+            dB,
+            d2B,
+            flats.psi.value,
+            flats.psi.velocity,
+            flats.psi.acceleration,
+            J,
+        )
+
+        ref = QuadrotorCsPayloadRefState(
+            payload_position=x_L[0],
+            payload_velocity=x_L[1],
+            payload_acceleration=x_L[2],
+            position=xQ,
+            velocity=vQ,
+            acceleration=aQ,
+            cable_attitude=q,
+            cable_angular_velocity=omega_cable,
+            cable_angular_acceleration=domega_cable,
+            orientation=SO3(R),
+            angular_velocity=TSO3(Omega),
+            angular_acceleration=dOmega,
+        )
+        inputs = QuadrotorCsPayloadInputs(thrust=f, moment=moment, tension=tension)
+        return ref, inputs


### PR DESCRIPTION
**Breakup of #8 — part 3.** Stacked on `feature/flatness-quadrotor`. Adds the cable-suspended-payload map (`QuadrotorCsPayload` + `cable_direction_jet`) + tests + ODE harness. Merge after the Quadrotor PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)