### PR TITLE
Flatness refactor: shared derivative engine + general cable tension-direction jet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -154,3 +154,6 @@ dmypy.json
 GYMNASIUM_PLAN.md
 LANDSCAPE.md
 refactor.md
+
+# uv lockfile (kept locally, resolved per-environment)
+uv.lock

--- a/docs/udaan.flatness.cable.rst
+++ b/docs/udaan.flatness.cable.rst
@@ -1,0 +1,7 @@
+udaan.flatness.cable module
+===========================
+
+.. automodule:: udaan.flatness.cable
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/udaan.flatness.derivatives.rst
+++ b/docs/udaan.flatness.derivatives.rst
@@ -1,0 +1,7 @@
+udaan.flatness.derivatives module
+=================================
+
+.. automodule:: udaan.flatness.derivatives
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/udaan.flatness.rst
+++ b/docs/udaan.flatness.rst
@@ -8,6 +8,8 @@ Submodules
    :maxdepth: 2
 
    udaan.flatness.base
+   udaan.flatness.cable
+   udaan.flatness.derivatives
    udaan.flatness.jet
    udaan.flatness.quadrotor
    udaan.flatness.quadrotor_cspayload

--- a/tests/flatness/test_cable.py
+++ b/tests/flatness/test_cable.py
@@ -1,0 +1,97 @@
+"""Tests for the shared cable-kinematics primitives (:mod:`udaan.flatness.cable`).
+
+Covers the general :func:`tension_direction_jet` (on a force jet that is *not* of
+the point-mass form, to exercise the generalisation), the point-mass Newton
+force jet, and the equivalence of the ``cable_direction_jet`` convenience
+composition with the earlier inlined behaviour.
+"""
+
+from __future__ import annotations
+
+from math import comb
+
+import numpy as np
+import pytest
+
+from udaan.flatness import (
+    cable_direction_jet,
+    normalize_derivatives,
+    point_mass_cable_force,
+    tension_direction_jet,
+)
+from udaan.flatness import quadrotor_cspayload as qcp
+
+
+def test_tension_direction_jet_general_force():
+    """Decompose an arbitrary cable-force jet ``F = T q`` — one whose tension
+    *and* direction both vary, i.e. NOT the point-mass ``-m(a+ge3)`` form — and
+    check the defining identities hold at every order: ``F = T·q`` and
+    ``‖q‖ ≡ 1``.  This is the 'tension-as-flat-output' regime."""
+    # Build a force jet directly (as an allocation would hand us), order K=4.
+    rng = np.random.default_rng(7)
+    K = 4
+    force = [rng.standard_normal(3) for _ in range(K + 1)]
+    force[0] += 5.0  # keep ‖F‖ well away from zero
+
+    T, q = tension_direction_jet(force)
+
+    # T[0] = ‖F‖ ≥ 0
+    assert T[0] == pytest.approx(float(np.linalg.norm(force[0])))
+    assert T[0] > 0
+
+    # F^(k) == sum_j C(k,j) T^(j) q^(k-j)   (Leibniz reconstruction of F = T q)
+    for k in range(K + 1):
+        recon = sum(comb(k, j) * T[j] * q[k - j] for j in range(k + 1))
+        np.testing.assert_allclose(recon, force[k], rtol=0, atol=1e-9)
+
+    # ‖q‖^2 ≡ 1  ->  its derivatives vanish beyond order 0
+    qq = [
+        sum(comb(k, j) * float(np.dot(q[j], q[k - j])) for j in range(k + 1)) for k in range(K + 1)
+    ]
+    assert qq[0] == pytest.approx(1.0)
+    for k in range(1, K + 1):
+        assert qq[k] == pytest.approx(0.0, abs=1e-9)
+
+
+def test_point_mass_cable_force_newton():
+    """F = -m_L (a_L + g e3) at order 0; higher orders = -m_L a_L^(k)."""
+    m, g = 0.5, 9.81
+    a = [np.array([0.1, -0.2, 0.3]), np.array([1.0, 0.0, -1.0]), np.array([0.0, 2.0, 0.0])]
+    force = point_mass_cable_force(a, m, g)
+    np.testing.assert_allclose(force[0], -m * (a[0] + g * np.array([0, 0, 1.0])))
+    np.testing.assert_allclose(force[1], -m * a[1])
+    np.testing.assert_allclose(force[2], -m * a[2])
+
+
+def test_cable_direction_jet_is_composition():
+    """cable_direction_jet == tension_direction_jet ∘ point_mass_cable_force,
+    and matches a direct normalize_derivatives of the Newton force (the earlier
+    inlined behaviour) exactly."""
+    m, g = 0.8, 9.81
+    a = [np.array([0.2, 0.1, -0.4]), np.array([0.5, -0.3, 0.1]), np.array([-0.2, 0.0, 0.7])]
+
+    T1, q1 = cable_direction_jet(a, m, g)
+    T2, q2 = tension_direction_jet(point_mass_cable_force(a, m, g))
+    # legacy path: normalize the hand-built Newton force tuple
+    tvec = [-m * (a[0] + g * np.array([0, 0, 1.0]))] + [-m * a[k] for k in range(1, len(a))]
+    T3, q3 = normalize_derivatives(tvec)
+
+    np.testing.assert_allclose(T1, T2)
+    np.testing.assert_allclose(T1, T3)
+    for k in range(len(a)):
+        np.testing.assert_allclose(q1[k], q2[k])
+        np.testing.assert_allclose(q1[k], q3[k])
+
+
+def test_reexport_identity():
+    """The name re-exported from quadrotor_cspayload is the same object, so the
+    controller's existing import keeps working."""
+    assert qcp.cable_direction_jet is cable_direction_jet
+
+
+def test_slack_cable_raises():
+    with pytest.raises(ValueError):
+        tension_direction_jet([np.zeros(3), np.ones(3)])
+    # point-mass payload in free fall: a_L = -g e3  ->  F = 0
+    with pytest.raises(ValueError):
+        cable_direction_jet([np.array([0.0, 0.0, -9.81]), np.zeros(3)], 1.0, 9.81)

--- a/tests/flatness/test_derivatives.py
+++ b/tests/flatness/test_derivatives.py
@@ -1,0 +1,153 @@
+"""Tests for the shared derivative engine (:mod:`udaan.flatness.derivatives`).
+
+The Leibniz recursions are verified two independent ways:
+
+* **Exact algebraic identities** that must hold at *arbitrary* order for any
+  input — polynomial ground truth for the products, and the defining relations
+  ``v = ‖v‖·u`` and ``‖u‖ ≡ 1`` for :func:`normalize_derivatives`.  These carry no
+  floating-point truncation error, so they pin the recursion at high order.
+* A **finite-difference anchor** on a genuine analytic signal, cross-checking the
+  norm/direction derivatives against an entirely different method at low order.
+"""
+
+from __future__ import annotations
+
+from math import comb
+
+import numpy as np
+import pytest
+
+from udaan.flatness import leibniz_dot, leibniz_product, normalize_derivatives
+
+
+def _poly_derivs(coeffs: list[float], t: float, order: int) -> list[float]:
+    """Derivative tuple ``[p, ṗ, …, p^(order)]`` at ``t`` of the polynomial with
+    the given power-basis ``coeffs`` (``coeffs[i]`` multiplies ``t**i``)."""
+    out = []
+    for k in range(order + 1):
+        val = 0.0
+        for i, c in enumerate(coeffs):
+            if i >= k:
+                # d^k/dt^k of c t^i = c * i!/(i-k)! * t^(i-k)
+                fall = 1
+                for m in range(k):
+                    fall *= i - m
+                val += c * fall * t ** (i - k)
+        out.append(val)
+    return out
+
+
+def test_leibniz_product_matches_polynomial():
+    # a(t) = t^2, b(t) = t^3  ->  a*b = t^5, whose derivatives are known exactly.
+    t0 = 1.7
+    order = 6
+    a = _poly_derivs([0, 0, 1], t0, order)  # t^2
+    b = _poly_derivs([0, 0, 0, 1], t0, order)  # t^3
+    prod = _poly_derivs([0, 0, 0, 0, 0, 1], t0, order)  # t^5
+    got = leibniz_product(a, b)
+    np.testing.assert_allclose(got, prod, rtol=0, atol=1e-9)
+
+
+def test_leibniz_dot_matches_polynomial():
+    # a(t) = [t^2, t, 1], b(t) = [1, t^2, t]  ->  <a,b> = t^2 + t^3 + t.
+    t0 = 0.9
+    order = 5
+    ax = [_poly_derivs(c, t0, order) for c in ([0, 0, 1], [0, 1], [1])]
+    bx = [_poly_derivs(c, t0, order) for c in ([1], [0, 0, 1], [0, 1])]
+    a = [np.array([ax[0][k], ax[1][k], ax[2][k]]) for k in range(order + 1)]
+    b = [np.array([bx[0][k], bx[1][k], bx[2][k]]) for k in range(order + 1)]
+    expected = _poly_derivs([0, 1, 1, 1], t0, order)  # t + t^2 + t^3
+    got = leibniz_dot(a, b)
+    np.testing.assert_allclose(got, expected, rtol=0, atol=1e-9)
+
+
+@pytest.mark.parametrize("order", [0, 1, 2, 3, 4, 5, 6])
+def test_normalize_reconstruction_and_unit_identities(order):
+    """For an arbitrary derivative tuple, ``normalize_derivatives`` must satisfy
+    the exact relations it is defined by, at every order:
+
+    * n[0] = ‖v[0]‖,
+    * v = ‖v‖·u   (Leibniz reconstruction of v from n and u),
+    * ‖u‖ ≡ 1     (so leibniz_dot(u,u) = [1, 0, 0, …]).
+    """
+    rng = np.random.default_rng(20260717 + order)
+    v = [rng.standard_normal(3) for _ in range(order + 1)]
+    v[0] += 3.0 * np.sign(v[0] + 1e-9)  # keep it comfortably away from zero norm
+
+    n, u = normalize_derivatives(v)
+
+    assert n[0] == pytest.approx(float(np.linalg.norm(v[0])))
+
+    # v^(k) == sum_j C(k,j) n^(j) u^(k-j)
+    for k in range(order + 1):
+        recon = sum(comb(k, j) * n[j] * u[k - j] for j in range(k + 1))
+        np.testing.assert_allclose(recon, v[k], rtol=0, atol=1e-9)
+
+    # ‖u‖^2 ≡ 1  ->  its 0th derivative is 1 and all higher derivatives vanish.
+    uu = leibniz_dot(u, u)
+    assert uu[0] == pytest.approx(1.0)
+    for k in range(1, order + 1):
+        assert uu[k] == pytest.approx(0.0, abs=1e-9)
+
+
+def test_normalize_matches_finite_difference():
+    """Anchor the norm/direction derivatives against central finite differences
+    of a genuine analytic signal, independent of the Leibniz recursion."""
+    t0, order = 0.35, 3
+
+    def signal(t):
+        return np.array([np.cos(t), np.sin(2.0 * t), t + 2.0])
+
+    # exact derivative tuple of `signal` at t0
+    def signal_derivs(t):
+        d = []
+        for k in range(order + 1):
+            d.append(
+                np.array(
+                    [
+                        np.cos(t + k * np.pi / 2),  # d^k cos t
+                        (2.0**k) * np.sin(2.0 * t + k * np.pi / 2),  # d^k sin 2t
+                        (t + 2.0) if k == 0 else (1.0 if k == 1 else 0.0),
+                    ]
+                )
+            )
+        return d
+
+    n, u = normalize_derivatives(signal_derivs(t0))
+
+    # central finite differences of ‖signal‖ and signal/‖signal‖
+    h = 1e-3
+
+    def norm_of(t):
+        return float(np.linalg.norm(signal(t)))
+
+    def dir_of(t):
+        s = signal(t)
+        return s / np.linalg.norm(s)
+
+    # 1st–3rd central-difference stencils
+    fd_n1 = (norm_of(t0 + h) - norm_of(t0 - h)) / (2 * h)
+    fd_n2 = (norm_of(t0 + h) - 2 * norm_of(t0) + norm_of(t0 - h)) / h**2
+    fd_n3 = (
+        norm_of(t0 + 2 * h) - 2 * norm_of(t0 + h) + 2 * norm_of(t0 - h) - norm_of(t0 - 2 * h)
+    ) / (2 * h**3)
+    assert n[1] == pytest.approx(fd_n1, abs=1e-5)
+    assert n[2] == pytest.approx(fd_n2, abs=1e-4)
+    assert n[3] == pytest.approx(fd_n3, abs=1e-3)
+
+    fd_u1 = (dir_of(t0 + h) - dir_of(t0 - h)) / (2 * h)
+    fd_u2 = (dir_of(t0 + h) - 2 * dir_of(t0) + dir_of(t0 - h)) / h**2
+    np.testing.assert_allclose(u[1], fd_u1, atol=1e-5)
+    np.testing.assert_allclose(u[2], fd_u2, atol=1e-4)
+
+
+def test_free_fall_singularity_raises():
+    with pytest.raises(ValueError):
+        normalize_derivatives([np.zeros(3), np.ones(3)])
+
+
+def test_leibniz_length_mismatch_raises():
+    with pytest.raises(ValueError):
+        leibniz_product([1.0, 2.0], [1.0])
+    with pytest.raises(ValueError):
+        leibniz_dot([np.ones(3)], [np.ones(3), np.ones(3)])

--- a/udaan/flatness/__init__.py
+++ b/udaan/flatness/__init__.py
@@ -16,6 +16,9 @@ with a cable-suspended point-mass payload, with flat output
 """
 
 from .base import Flat2State as Flat2State
+from .cable import cable_direction_jet as cable_direction_jet
+from .cable import point_mass_cable_force as point_mass_cable_force
+from .cable import tension_direction_jet as tension_direction_jet
 from .derivatives import leibniz_dot as leibniz_dot
 from .derivatives import leibniz_product as leibniz_product
 from .derivatives import normalize_derivatives as normalize_derivatives
@@ -49,9 +52,12 @@ __all__ = [
     "Flat2State",
     "Jet",
     "Quadrotor",
+    "cable_direction_jet",
     "leibniz_dot",
     "leibniz_product",
     "normalize_derivatives",
+    "point_mass_cable_force",
+    "tension_direction_jet",
     "QuadrotorCsPayload",
     "QuadrotorCsPayloadFlats",
     "QuadrotorCsPayloadInputs",

--- a/udaan/flatness/__init__.py
+++ b/udaan/flatness/__init__.py
@@ -16,6 +16,9 @@ with a cable-suspended point-mass payload, with flat output
 """
 
 from .base import Flat2State as Flat2State
+from .derivatives import leibniz_dot as leibniz_dot
+from .derivatives import leibniz_product as leibniz_product
+from .derivatives import normalize_derivatives as normalize_derivatives
 from .jet import Jet as Jet
 from .quadrotor import (
     Quadrotor as Quadrotor,
@@ -46,6 +49,9 @@ __all__ = [
     "Flat2State",
     "Jet",
     "Quadrotor",
+    "leibniz_dot",
+    "leibniz_product",
+    "normalize_derivatives",
     "QuadrotorCsPayload",
     "QuadrotorCsPayloadFlats",
     "QuadrotorCsPayloadInputs",

--- a/udaan/flatness/cable.py
+++ b/udaan/flatness/cable.py
@@ -1,0 +1,89 @@
+"""Cable-kinematics jets shared across cable-suspended-load flatness maps.
+
+A taut, massless cable transmits a force ``F = T q`` where ``T ≥ 0`` is the
+scalar tension and ``q`` is the unit direction the cable pulls along (this
+codebase's convention: ``q`` points from the quadrotor to the load).  Flatness
+maps for cable-suspended systems repeatedly need the time-derivative tuples
+("jets") of ``T`` and ``q`` given the cable-force jet.  That single operation is
+:func:`tension_direction_jet`, built on the shared Leibniz engine
+(:func:`udaan.flatness.derivatives.normalize_derivatives`).
+
+The *force* jet itself is model-specific:
+
+* a single point-mass payload — this repo's cable-suspended-payload system, and
+  each independent link of a multi-quad point-mass system — obeys Newton's law
+  ``F = -m_L (a_L + g e3)``: :func:`point_mass_cable_force`;
+* a rigid-body payload carried by several cables is over-actuated, so the
+  per-cable force comes from a wrench→tension allocation (a separate primitive)
+  in which the tension is a *free / flat* quantity; the resulting force jet
+  decomposes with the very same :func:`tension_direction_jet`.
+
+Because the input is the force vector rather than the load acceleration,
+:func:`tension_direction_jet` serves both regimes — it does not assume the
+tension is determined by the load dynamics.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from ..core.defaults import GRAVITY
+from .derivatives import normalize_derivatives
+
+__all__ = ["tension_direction_jet", "point_mass_cable_force", "cable_direction_jet"]
+
+_E3 = np.array([0.0, 0.0, 1.0])
+
+
+def tension_direction_jet(
+    cable_force: list[np.ndarray],
+) -> tuple[list[float], list[np.ndarray]]:
+    """Tension-magnitude and unit-direction jets of a taut cable.
+
+    Given the derivative tuple ``cable_force = [F, Ḟ, …, F^(K)]`` of the cable
+    force vector ``F = T q`` (scalar tension ``T ≥ 0``, unit pull direction
+    ``q``), return ``(T, q)`` where ``T[k] = (d/dt)^k T`` (scalar) and
+    ``q[k] = (d/dt)^k q`` (vector) for ``k = 0 … K``.
+
+    This is the general "tension→direction jet": it takes the cable *force* as
+    input, so it applies whether the force is fixed by the load dynamics (single
+    payload) or chosen by a wrench→tension allocation (rigid-body / multi-cable,
+    where the tension is a flat output).  It is a thin cable-semantics wrapper
+    over :func:`~udaan.flatness.derivatives.normalize_derivatives`.
+
+    Raises
+    ------
+    ValueError
+        On a slack cable (``‖F‖ ≈ 0``): the pull direction is undefined.
+    """
+    return normalize_derivatives(cable_force)
+
+
+def point_mass_cable_force(
+    payload_accel: list[np.ndarray], mass_l: float, gravity: float = GRAVITY
+) -> list[np.ndarray]:
+    """Cable-force jet holding up a point-mass load, from its acceleration jet.
+
+    Newton's law on a point mass ``m_L`` gives the cable force
+    ``F = -m_L (a_L + g e3)`` (the cable pulls the load, ``q`` points
+    quadrotor→load).  Given ``payload_accel = [a_L, ȧ_L, …, a_L^(K)]`` return
+    the force derivative tuple ``[F, Ḟ, …, F^(K)]`` (gravity is constant, so it
+    contributes only to the zeroth term).
+    """
+    force = [-mass_l * (payload_accel[0] + gravity * _E3)]
+    for k in range(1, len(payload_accel)):
+        force.append(-mass_l * payload_accel[k])
+    return force
+
+
+def cable_direction_jet(
+    payload_accel: list[np.ndarray], mass_l: float, gravity: float = GRAVITY
+) -> tuple[list[float], list[np.ndarray]]:
+    """Tension and unit-direction jets for a point-mass cable-suspended payload.
+
+    Convenience composition of :func:`point_mass_cable_force` and
+    :func:`tension_direction_jet` — the single-payload specialisation used by the
+    quadrotor / cable-suspended-payload map and controller.  See those functions
+    for the convention and the free-fall (slack-cable) :class:`ValueError`.
+    """
+    return tension_direction_jet(point_mass_cable_force(payload_accel, mass_l, gravity))

--- a/udaan/flatness/derivatives.py
+++ b/udaan/flatness/derivatives.py
@@ -1,0 +1,110 @@
+"""Arbitrary-order time-derivative algebra for differential-flatness maps.
+
+Every flat-to-state map in this package pushes the time derivatives of the flat
+output through the system dynamics.  Doing so by hand (or with a one-off
+symbolic dump) does not scale past the first system, so the recurring operations
+are collected here as a small **shared derivative engine**: given the
+time-derivative tuples of one or more signals, build the derivative tuple of
+their product, inner product, norm, and normalized direction via the Leibniz
+rule.
+
+A *derivative tuple* is ``[s, ṡ, s̈, …, s^(K)]`` — a signal's value together with
+all of its time derivatives up to order ``K`` at one instant (the same object
+carried by :class:`~udaan.flatness.jet.Jet`).  These closed-form recursions are
+exact at arbitrary order and are reused by every per-system map (the
+quadrotor / cable-suspended-payload maps today; the multi-cable systems next).
+"""
+
+from __future__ import annotations
+
+from math import comb
+
+import numpy as np
+
+__all__ = ["leibniz_product", "leibniz_dot", "normalize_derivatives"]
+
+
+def leibniz_product(a: list, b: list) -> list:
+    """Derivative tuple of the product ``a(t) · b(t)`` (elementwise / scalar).
+
+    Given derivative tuples ``a = [a, ȧ, …, a^(K)]`` and ``b`` of equal length,
+    return ``c`` with ``c[k] = (d/dt)^k (a b) = Σ_j C(k,j) a^(j) b^(k-j)``.
+
+    ``a`` and ``b`` may be scalars or NumPy arrays (broadcast elementwise); the
+    result matches their shape.
+    """
+    if len(a) != len(b):
+        raise ValueError("leibniz_product: derivative tuples must have equal length")
+    K = len(a) - 1
+    return [sum(comb(k, j) * a[j] * b[k - j] for j in range(k + 1)) for k in range(K + 1)]
+
+
+def leibniz_dot(a: list[np.ndarray], b: list[np.ndarray]) -> list[float]:
+    """Derivative tuple of the inner product ``⟨a(t), b(t)⟩``.
+
+    Given derivative tuples of two vector signals of equal length, return the
+    scalar derivative tuple ``c`` with
+    ``c[k] = (d/dt)^k ⟨a, b⟩ = Σ_j C(k,j) ⟨a^(j), b^(k-j)⟩``.
+    """
+    if len(a) != len(b):
+        raise ValueError("leibniz_dot: derivative tuples must have equal length")
+    K = len(a) - 1
+    out = []
+    for k in range(K + 1):
+        s = 0.0
+        for j in range(k + 1):
+            s += comb(k, j) * float(np.dot(a[j], b[k - j]))
+        out.append(s)
+    return out
+
+
+def normalize_derivatives(
+    v: list[np.ndarray],
+) -> tuple[list[float], list[np.ndarray]]:
+    """Derivative tuples of the norm and unit direction of a vector signal.
+
+    Given the derivative tuple ``v = [v, v̇, v̈, …, v^(K)]`` of a non-vanishing
+    vector signal, return ``(n, u)`` where ``n[k] = (d/dt)^k ‖v‖`` (scalar) and
+    ``u[k] = (d/dt)^k (v / ‖v‖)`` (vector) for ``k = 0, 1, …, K``.
+
+    The recursions follow from ``‖v‖² = ⟨v, v⟩`` and ``v = ‖v‖ · u``:
+
+        (‖v‖²)^(k) = Σ_{j=0}^{k} C(k,j) ⟨v^(j), v^(k-j)⟩        (Leibniz)
+        n^(k)      = ((‖v‖²)^(k) − Σ_{j=1}^{k-1} C(k,j) n^(j) n^(k-j)) / (2 n)
+        u^(k)      = (v^(k) − Σ_{j=1}^{k} C(k,j) n^(j) u^(k-j)) / n
+
+    Raises
+    ------
+    ValueError
+        If ``v`` vanishes (``‖v‖ ≈ 0``): the direction is undefined — this is the
+        free-fall / slack-cable singularity of the flatness maps that call it.
+    """
+    K = len(v) - 1
+    n_val = float(np.linalg.norm(v[0]))
+    if n_val < 1e-9:
+        raise ValueError(
+            "normalize_derivatives: input vector has zero norm — singularity in the flatness map."
+        )
+
+    # n²[k] := (d/dt)^k ‖v‖² via the Leibniz inner-product rule.
+    n_sq = leibniz_dot(v, v)
+
+    # n[k] by differentiating ‖v‖² = ‖v‖·‖v‖ and solving for the top term:
+    #   (‖v‖²)^(k) = Σ_j C(k,j) n^(j) n^(k-j)  ⇒  2 n n^(k) = (‖v‖²)^(k) − (inner terms)
+    n = [n_val]
+    for k in range(1, K + 1):
+        s = n_sq[k]
+        for j in range(1, k):
+            s -= comb(k, j) * n[j] * n[k - j]
+        n.append(s / (2.0 * n_val))
+
+    # u[k] by differentiating v = n·u and solving for the top term:
+    #   v^(k) = Σ_j C(k,j) n^(j) u^(k-j)  ⇒  n u^(k) = v^(k) − (inner terms)
+    u = [v[0] / n_val]
+    for k in range(1, K + 1):
+        s = np.array(v[k], dtype=float)
+        for j in range(1, k + 1):
+            s -= comb(k, j) * n[j] * u[k - j]
+        u.append(s / n_val)
+
+    return n, u

--- a/udaan/flatness/quadrotor_cspayload.py
+++ b/udaan/flatness/quadrotor_cspayload.py
@@ -31,7 +31,6 @@ Reference:
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from math import comb
 
 import numpy as np
 
@@ -45,6 +44,7 @@ from ..core.defaults import (
 from ..core.types import Mat3, Vec3
 from ..manif import S2, SO3, TS2, TSO3
 from .base import Flat2State
+from .derivatives import normalize_derivatives
 from .jet import Jet
 from .quadrotor import _attitude_from_thrust_vector
 
@@ -53,58 +53,6 @@ _E3 = np.array([0.0, 0.0, 1.0])
 
 def _zeros3() -> Vec3:
     return np.zeros(3)
-
-
-def _normalize_derivatives(v: list[np.ndarray]) -> tuple[list[float], list[np.ndarray]]:
-    """Given the time-derivative tuple ``v = [v, v̇, v̈, …, v^(K)]`` of a
-    non-vanishing vector signal, return ``(n, u)`` where ``n[k] = (d/dt)^k ‖v‖``
-    and ``u[k] = (d/dt)^k (v / ‖v‖)`` for k = 0, 1, …, K.
-
-    Uses the Leibniz expansions
-        (n²)^(k) = sum_{j=0}^{k} C(k,j) v^(j) · v^(k-j),
-        u^(k)   = (v^(k) - sum_{j=1}^{k} C(k,j) n^(j) u^(k-j)) / n,
-    and the closed-form recursion for n^(k) by differentiating ``n² = n·n``.
-
-    Raises ``ValueError`` on a vanishing v (free-fall singularity in the
-    flatness map).
-    """
-    K = len(v) - 1
-    n_val = float(np.linalg.norm(v[0]))
-    if n_val < 1e-9:
-        raise ValueError(
-            "_normalize_derivatives: input vector has zero norm — singularity in the flatness map."
-        )
-
-    # n²[k] := (d/dt)^k (‖v‖²)
-    n_sq = []
-    for k in range(K + 1):
-        s = np.zeros_like(v[0], dtype=float)[..., 0] if False else 0.0
-        s = 0.0
-        for j in range(k + 1):
-            s += comb(k, j) * float(v[j].dot(v[k - j]))
-        n_sq.append(s)
-
-    # n[k] from the Leibniz expansion of (n·n) = n²:
-    #   (n²)^(k) = sum_{j=0}^{k} C(k,j) n^(j) n^(k-j)
-    #   2 n n^(k) = (n²)^(k) - sum_{j=1}^{k-1} C(k,j) n^(j) n^(k-j)
-    n = [n_val]
-    for k in range(1, K + 1):
-        s = n_sq[k]
-        for j in range(1, k):
-            s -= comb(k, j) * n[j] * n[k - j]
-        n.append(s / (2.0 * n_val))
-
-    # u[k] from u·n = v:
-    #   v^(k) = sum_{j=0}^{k} C(k,j) u^(j) n^(k-j)
-    #   u^(k) = (v^(k) - sum_{j=1}^{k} C(k,j) n^(j) u^(k-j)) / n
-    u = [v[0] / n_val]
-    for k in range(1, K + 1):
-        s = v[k].copy()
-        for j in range(1, k + 1):
-            s -= comb(k, j) * n[j] * u[k - j]
-        u.append(s / n_val)
-
-    return n, u
 
 
 def cable_direction_jet(
@@ -116,8 +64,8 @@ def cable_direction_jet(
     ``T q = -m_L (a_L + g e3)``, where ``q`` is the unit cable direction
     (quadrotor → payload).  Given ``payload_accel = [a_L, ȧ_L, …, a_L^(K)]``,
     return ``(T, q)`` where ``T[k] = (d/dt)^k T`` is the k-th derivative of the
-    scalar cable tension and ``q[k] = (d/dt)^k q`` for k = 0…K, via the Leibniz
-    :func:`_normalize_derivatives` chain.
+    scalar cable tension and ``q[k] = (d/dt)^k q`` for k = 0…K, via the shared
+    Leibniz :func:`~udaan.flatness.derivatives.normalize_derivatives` chain.
 
     Raises ``ValueError`` if the payload is in free fall (``a_L + g e3 ≈ 0``):
     the cable goes slack and ``q`` is undefined.
@@ -125,7 +73,7 @@ def cable_direction_jet(
     tvec = [-mass_l * (payload_accel[0] + gravity * _E3)]
     for k in range(1, len(payload_accel)):
         tvec.append(-mass_l * payload_accel[k])
-    return _normalize_derivatives(tvec)
+    return normalize_derivatives(tvec)
 
 
 @dataclass

--- a/udaan/flatness/quadrotor_cspayload.py
+++ b/udaan/flatness/quadrotor_cspayload.py
@@ -44,7 +44,9 @@ from ..core.defaults import (
 from ..core.types import Mat3, Vec3
 from ..manif import S2, SO3, TS2, TSO3
 from .base import Flat2State
-from .derivatives import normalize_derivatives
+from .cable import (
+    cable_direction_jet as cable_direction_jet,  # re-export (used by controller + recover)
+)
 from .jet import Jet
 from .quadrotor import _attitude_from_thrust_vector
 
@@ -53,27 +55,6 @@ _E3 = np.array([0.0, 0.0, 1.0])
 
 def _zeros3() -> Vec3:
     return np.zeros(3)
-
-
-def cable_direction_jet(
-    payload_accel: list[np.ndarray], mass_l: float, gravity: float = GRAVITY
-) -> tuple[list[float], list[np.ndarray]]:
-    """Cable tension and unit-direction jets from the payload-acceleration jet.
-
-    Newton's law on the point-mass payload gives the cable force
-    ``T q = -m_L (a_L + g e3)``, where ``q`` is the unit cable direction
-    (quadrotor → payload).  Given ``payload_accel = [a_L, ȧ_L, …, a_L^(K)]``,
-    return ``(T, q)`` where ``T[k] = (d/dt)^k T`` is the k-th derivative of the
-    scalar cable tension and ``q[k] = (d/dt)^k q`` for k = 0…K, via the shared
-    Leibniz :func:`~udaan.flatness.derivatives.normalize_derivatives` chain.
-
-    Raises ``ValueError`` if the payload is in free fall (``a_L + g e3 ≈ 0``):
-    the cable goes slack and ``q`` is undefined.
-    """
-    tvec = [-mass_l * (payload_accel[0] + gravity * _E3)]
-    for k in range(1, len(payload_accel)):
-        tvec.append(-mass_l * payload_accel[k])
-    return normalize_derivatives(tvec)
 
 
 @dataclass


### PR DESCRIPTION
Extracts the reusable machinery that was fused inside the cable-suspended-payload flatness map, so the multi-cable systems can build on it instead of re-deriving it.

## Commits

1. **Shared arbitrary-order derivative engine** — promotes the Leibniz normalization recursion into a public `udaan/flatness/derivatives.py` (`normalize_derivatives`, plus the `leibniz_dot` / `leibniz_product` primitives it is built from), and migrates `quadrotor_cspayload` off its private copy (dropping dead `if False` scaffolding and an unused `math.comb` import).
2. **Shared cable tension-direction jet** — new `udaan/flatness/cable.py`. `tension_direction_jet(cable_force)` decomposes an arbitrary cable-force jet `F = T q` into tension-magnitude and unit-direction jets; taking the *force* rather than the load acceleration as input means it also covers the tension-as-flat-output regime the multi-cable systems need. `point_mass_cable_force` is the Newton step. `cable_direction_jet` becomes the composition of the two, re-exported from `quadrotor_cspayload` so the map and payload controller import it unchanged.
3. **Autodoc stubs** for the two new modules, wired into the package toctree (the docs build enumerates submodules explicitly).
4. **Ignore `uv.lock`** — resolved per-environment, but must stay next to `pyproject.toml` for uv, so it is ignored in place.

## Testing

Two new suites covering machinery that previously had only indirect coverage:

- `test_derivatives.py` — polynomial ground truth for the products; exact arbitrary-order identities (`v = |v|u`, `|u| = 1`) for K = 0..6, which carry no truncation error and so pin the recursion at high order; an independent finite-difference anchor; singularity and length-mismatch guards.
- `test_cable.py` — the general decomposition exercised on a force jet deliberately *not* of the point-mass form; Newton force correctness; equivalence of the composition with the previous inlined behaviour; re-export identity; slack-cable guards.

301 tests pass (`tests/test_quadrotor_mujoco.py` and `tests/test_quadrotor_cspayload_mujoco.py` are excluded — they fail to collect on `main` already, unrelated to this change). Ruff and pre-commit clean.

## Scope

No behaviour change: the map and controller produce identical results, verified by the equivalence test against the previous inlined path.

Cable-chain recursion and the wrench-to-tension allocation that *chooses* the tension are deliberately left out — they are separate board items pending the multi-cable models.